### PR TITLE
Collision distance evaluator update

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,16 @@ Parameters:
   - The name of the planning group to be used to solve the robot's inverse kinematics
 - **`distance_threshold`**
   - The distance between 2 closest surfaces to collision under which an inverse kinematics solution will be considered invalid
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The filename (in ROS package URI format) of the reach object mesh to be used to do collision checking
   - Example: `package://<your_package>/<folder>/<filename>.stl
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**
   - The names of the robot links with which the reach object mesh is allowed to collide
 - **`exponent`**
-  - score = (closest_distance_to_collision - distance_threshold)^exponent.
+  - score = (closest_distance_to_collision / distance_threshold)^exponent.
 
 ### Joint Penalty
 
@@ -146,9 +146,9 @@ Parameters:
 - **`distance_threshold`**
   - The distance from nearest collision at which to invalidate an IK solution. For example, if this parameter is
   set to 0.1m, then IK solutions whose distance to nearest collision is less than 0.1m will be invalidated
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The file path to the collision mesh model of the workpiece, in the `package://` or 'file://' URI format
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**
@@ -168,9 +168,9 @@ Parameters:
 - **`distance_threshold`**
   - The distance from nearest collision at which to invalidate an IK solution. For example, if this parameter is
   set to 0.1m, then IK solutions whose distance to nearest collision is less than 0.1m will be invalidated
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The file path to the collision mesh model of the workpiece, in the `package://` or 'file://' URI format
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Parameters:
 
 This plugin uses the MoveIt! collision environment to calculate the distance to closest collision
 for a robot pose. That distance value is then used to score the robot pose. Larger distance to closest collision
-results in higher pose score. Range: [0, inf)
+results in higher pose score. Range: [0, 1]
 
 Parameters:
 
@@ -121,7 +121,7 @@ Parameters:
 - **`touch_links`**
   - The names of the robot links with which the reach object mesh is allowed to collide
 - **`exponent`**
-  - score = (closest_distance_to_collision / distance_threshold)^exponent.
+  - score = min(abs(closest_distance_to_collision / distance_threshold), 1.0)^exponent.
 
 ### Joint Penalty
 

--- a/demo/results/reach_study/reach.db.xml
+++ b/demo/results/reach_study/reach.db.xml
@@ -1806,7 +1806,7 @@
 						<second>-5.08985272695114510e-01</second>
 					</item>
 				</goal_state>
-				<score>1.58693416752215088e+00</score>
+				<score>1.08352620801873106e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -1869,34 +1869,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.93850295354228219e-01</second>
+						<second>-1.30302019609368869e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.13643503819191904e-01</second>
+						<second>2.96699999641151102e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58489453926075119e+00</second>
+						<second>-1.00838502667300434e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.70841942600749497e-01</second>
+						<second>1.71891159872975430e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.78446190093087842e+00</second>
+						<second>-2.01207152466652328e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.23927857945782338e+00</second>
+						<second>-1.91852221438193116e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.88169803298386040e-01</second>
+						<second>-7.88782627110774071e-01</second>
 					</item>
 				</goal_state>
-				<score>2.32288892988698636e+00</score>
+				<score>1.57635580920823165e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -1959,34 +1959,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>-9.15312559539705362e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>1.95301005015334561e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>-1.33214955192778595e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>8.86499679728613432e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>-1.74216111469801072e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>-2.01587987103196342e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>-8.58805020057116897e-01</second>
 					</item>
 				</goal_state>
-				<score>2.85399295583344736e+00</score>
+				<score>1.58695227439776598e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2049,34 +2049,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.25625441991713438e+00</second>
+						<second>1.39235518098740196e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.06463692436496760e+00</second>
+						<second>2.51337340781874996e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.52423258363754299e+00</second>
+						<second>-1.43396871069349352e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.09211298682184932e+00</second>
+						<second>-1.61685264299437015e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.22531969061136725e+00</second>
+						<second>-1.99659058323776306e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.24837128750967075e-01</second>
+						<second>-2.75465469517097272e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.00426143532976409e-01</second>
+						<second>-6.00435325448082535e-01</second>
 					</item>
 				</goal_state>
-				<score>1.97715042274547481e+00</score>
+				<score>1.41662939165822815e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2139,34 +2139,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.04431526914520534e+00</second>
+						<second>-1.30450215452717155e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.20118503365351259e+00</second>
+						<second>2.54826407883350825e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.24338319376832440e+00</second>
+						<second>-1.05209744758674528e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.58802670530156020e-01</second>
+						<second>1.42812041531538503e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.69236754112539955e+00</second>
+						<second>-1.85931997075465927e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.83944729130832219e+00</second>
+						<second>1.73532667331372875e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42673902531544927e-01</second>
+						<second>-9.42852205969985091e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46331657180142960e+00</score>
+				<score>1.78019274714205533e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2229,34 +2229,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>-8.21309617362023681e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>1.07703412724645520e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>-1.75963731549984415e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>-2.74486559979126465e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>-1.70854022868351474e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>8.13627268628478229e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>-1.06267059261650720e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97054593365499064e+00</score>
+				<score>1.86494038890021474e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2319,34 +2319,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>8.42402665292957264e-01</second>
+						<second>1.90002293987170301e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03972892611279999e+00</second>
+						<second>6.46003484800312444e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91738019749592126e+00</second>
+						<second>1.29993060972074304e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.05225107214299474e+00</second>
+						<second>-4.69075453698148237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.36289837240485867e+00</second>
+						<second>6.65829107847038304e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.45703089861990032e+00</second>
+						<second>-2.75008506656012175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.02760215446629810e+00</second>
+						<second>-1.02752767733299200e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56560501766347526e+00</score>
+				<score>2.02470908347816003e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2409,34 +2409,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75863181831619619e+00</second>
+						<second>1.78639554688497615e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>1.66859220213950565e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.50842630936993460e+00</second>
+						<second>1.86561445058855258e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.09844116343838927e+00</second>
+						<second>9.54704765518928911e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.22880811047857064e+00</second>
+						<second>5.31091071009272886e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.32223972544061102e-01</second>
+						<second>-2.28849610011947391e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.88941068081233787e-01</second>
+						<second>-6.89198557557483715e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34185636336967962e+00</score>
+				<score>1.52166805622665491e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2499,34 +2499,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>4.02815283377608413e-01</second>
+						<second>-4.61798720875975455e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.32196315313202661e+00</second>
+						<second>1.06202766827287109e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.74531476894885840e+00</second>
+						<second>-1.91975515429793830e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.06744628099968031e+00</second>
+						<second>-6.02502628632875736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.54681925022388733e+00</second>
+						<second>-1.61857504894266246e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.32901543069267669e+00</second>
+						<second>-1.30468615483258699e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.46472559637339095e+00</second>
+						<second>-1.46468272812080080e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71436649774492755e+00</score>
+				<score>1.50201475447027416e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2589,34 +2589,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.57576144585789724e-01</second>
+						<second>1.83504605920255459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.38520769557189194e+00</second>
+						<second>-2.75682755701901439e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56836191426743587e+00</second>
+						<second>1.05059154458068860e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.05820867373437810e+00</second>
+						<second>2.39084647300655684e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.57954272666457762e+00</second>
+						<second>6.59106808254213306e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.14777559698149437e-02</second>
+						<second>-2.99717002900289753e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48867782086259748e+00</second>
+						<second>1.48872238273390245e+00</second>
 					</item>
 				</goal_state>
-				<score>2.28036110839625605e+00</score>
+				<score>1.98867969337978123e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2679,37 +2679,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-9.61769435153357999e-01</second>
+						<second>1.08518840356152224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.53527393126922029e+00</second>
+						<second>-1.33261889670184663e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91920074441020461e+00</second>
+						<second>-1.76504019261446610e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.78051982417526200e-01</second>
+						<second>9.21071290492156303e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.78623868018483334e+00</second>
+						<second>-1.80247024801014399e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.54983483387536730e-01</second>
+						<second>3.14149997636372769e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11734054201285948e+00</second>
+						<second>1.11740531757494543e+00</second>
 					</item>
 				</goal_state>
-				<score>2.61844062927643639e+00</score>
+				<score>1.89183152797762932e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -2769,34 +2769,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.41882017900104551e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.77912807527765171e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.19004802590117054e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.10266307051439694e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>4.71835903595977588e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>7.94436605247711758e-01</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.62802781475126085e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2859,34 +2859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79938620655980785e+00</second>
+						<second>-1.55797369663684360e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.55471389223816203e+00</second>
+						<second>2.96699999963059735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.81086176083200789e+00</second>
+						<second>9.12130088755938706e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.07574367107000857e-01</second>
+						<second>-8.59631023003549544e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.77510794894695262e-02</second>
+						<second>8.92495716358120417e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.42870290818992296e+00</second>
+						<second>-2.95503591783539399e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83966934771623625e+00</second>
+						<second>1.83959999216321290e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79344021444480561e+00</score>
+				<score>1.59707693717475924e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2949,37 +2949,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82319241455661607e+00</second>
+						<second>-1.91979923073623393e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.76432290108184131e+00</second>
+						<second>2.04500607428199366e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.83059383206950188e+00</second>
+						<second>1.16506166873862038e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39322415904739660e+00</second>
+						<second>2.55362940900216762e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.30057357177609689e-02</second>
+						<second>5.63592835145496407e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.91063108551034189e+00</second>
+						<second>1.08260529716796700e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64531392539713672e+00</second>
+						<second>-1.64526088903558665e+00</second>
 					</item>
 				</goal_state>
-				<score>2.29073110119196288e+00</score>
+				<score>1.90252103254152816e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3039,34 +3039,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91853791723182598e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.94018508722983141e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.86243381521110329e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>8.63336889286374976e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>4.32911997677641325e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>9.27791133008653013e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.26206716469288627e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.91996477060984300e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3129,34 +3129,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61574364709943974e+00</second>
+						<second>1.03973789720024801e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90554818157082639e+00</second>
+						<second>-1.05251545224272158e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.92251346147564184e-01</second>
+						<second>1.28611289725878608e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.36200116306952368e-01</second>
+						<second>-9.77150174829642837e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.98438125951423938e-01</second>
+						<second>1.36984207458603735e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14150000000000018e+00</second>
+						<second>-4.96761356832077727e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.02188840136405146e+00</second>
+						<second>-2.02194320998524013e+00</second>
 					</item>
 				</goal_state>
-				<score>2.10276731817181783e+00</score>
+				<score>1.07935756059814744e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3219,34 +3219,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.14844153663396731e-01</second>
+						<second>1.77686033803467591e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.73192004988739034e+00</second>
+						<second>1.30489951352783651e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91864127120909411e+00</second>
+						<second>1.79778876248953967e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.80174455230055464e+00</second>
+						<second>7.30950264626502255e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.68907017700687856e+00</second>
+						<second>-3.00165561252453639e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.77267913381770237e-01</second>
+						<second>-1.85610483269656723e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87535714819619037e+00</second>
+						<second>-1.87539661489507825e+00</second>
 					</item>
 				</goal_state>
-				<score>1.22198591871536810e+00</score>
+				<score>1.47423811105490549e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3309,37 +3309,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.26982882623827886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-9.69341467605065787e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.71515868386393522e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-1.43323171277181438e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-1.99045780804137040e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-5.42957063193649558e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.55311347196450478e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.73787434660543111e-01</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3359,96 +3359,6 @@
 						<item>6.51251435279846191e-01</item>
 						<item>1.73752665519714355e-01</item>
 						<item>4.03971880674362183e-01</item>
-						<item>1.00000000000000000e+00</item>
-					</matrix>
-				</goal>
-				<seed_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-				</seed_state>
-				<goal_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>-6.47944429134393096e-01</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>1.60098987279618732e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>1.91979993914931546e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>-6.76405795999474257e-01</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>1.41681737236231409e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>1.74845502027980615e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>2.13519190016531590e+00</second>
-					</item>
-				</goal_state>
-				<score>1.24091798083233673e+00</score>
-			</item>
-			<item>
-				<reached>0</reached>
-				<goal>
-					<matrix>
-						<count>16</count>
-						<item_version>0</item_version>
-						<item>-4.27560925483703613e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.03986811637878418e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>-4.79428544640542187e-02</item>
-						<item>-9.98592674732208252e-01</item>
-						<item>-2.26756520569325014e-02</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.02714550495147705e-01</item>
-						<item>-5.30349053442479429e-02</item>
-						<item>4.26959186792373657e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>6.74034774303436279e-01</item>
-						<item>1.49467647075653076e-01</item>
-						<item>3.48230361938476562e-01</item>
 						<item>1.00000000000000000e+00</item>
 					</matrix>
 				</goal>
@@ -3517,6 +3427,96 @@
 					</item>
 				</goal_state>
 				<score>0.00000000000000000e+00</score>
+			</item>
+			<item>
+				<reached>1</reached>
+				<goal>
+					<matrix>
+						<count>16</count>
+						<item_version>0</item_version>
+						<item>-4.27560925483703613e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.03986811637878418e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>-4.79428544640542187e-02</item>
+						<item>-9.98592674732208252e-01</item>
+						<item>-2.26756520569325014e-02</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.02714550495147705e-01</item>
+						<item>-5.30349053442479429e-02</item>
+						<item>4.26959186792373657e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>6.74034774303436279e-01</item>
+						<item>1.49467647075653076e-01</item>
+						<item>3.48230361938476562e-01</item>
+						<item>1.00000000000000000e+00</item>
+					</matrix>
+				</goal>
+				<seed_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</seed_state>
+				<goal_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>1.55785352896349361e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>-1.78716674134790710e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>-1.91979999999999995e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>8.49014274267227309e-01</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>2.55775186767138196e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>1.50336246325275247e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>-2.02108484133751043e+00</second>
+					</item>
+				</goal_state>
+				<score>1.17668058416539059e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -3609,7 +3609,7 @@
 				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3669,34 +3669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57569257089391246e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.14040635566775683e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68096307114115162e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.81583817027514560e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.37462622959069192e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.91915990374358558e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09715175932831377e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</goal_state>
-				<score>1.77962710494763554e+00</score>
+				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3759,37 +3759,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91602374417966748e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.96689212022231774e-01</second>
+						<second>2.60993243574549361e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.56050796079096377e+00</second>
+						<second>-1.46990424669438391e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.37611313566709503e-01</second>
+						<second>2.40937057711447977e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.56837785332447399e-01</second>
+						<second>-2.59515267602153665e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.40932585516797459e+00</second>
+						<second>-5.48829906523652711e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75231397035650582e+00</second>
+						<second>-1.75230748926813562e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00462437098543633e+00</score>
+				<score>1.73177595833408443e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3849,34 +3849,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.35301175679948860e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.31519507925604917e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91824071657997797e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.83048652865959460e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.28260304897316901e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.72213167351091867e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.09828264829451427e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.01790840319195455e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3939,34 +3939,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80936223138820074e+00</second>
+						<second>-1.32079173007449380e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.18157351707890723e-01</second>
+						<second>-2.02793613685261098e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.64704365904237804e+00</second>
+						<second>1.91979996941109698e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.71683304253661029e-01</second>
+						<second>1.26483468114102493e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59089943524871957e+00</second>
+						<second>-9.52325318936542597e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.36051824152801548e-01</second>
+						<second>9.28155993985702366e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.75076284062963028e+00</second>
+						<second>1.75073499317806958e+00</second>
 					</item>
 				</goal_state>
-				<score>2.61576370940917435e+00</score>
+				<score>1.44871445332620558e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4029,34 +4029,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91683362271037372e+00</second>
+						<second>1.91920518111169591e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.74133310932165264e+00</second>
+						<second>-4.10793048844071973e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.25611524772640415e-01</second>
+						<second>9.28572602207443643e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.87199025237881145e+00</second>
+						<second>2.63392559986039887e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.07072052509510796e-01</second>
+						<second>-9.86430911545799066e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.38525901095120929e-01</second>
+						<second>-3.47243669178234349e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14345041642589562e+00</second>
+						<second>-2.14340023777971034e+00</second>
 					</item>
 				</goal_state>
-				<score>1.12621523538947876e+00</score>
+				<score>1.10284512487524980e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4119,34 +4119,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91681744481860949e+00</second>
+						<second>1.56216659246488798e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.16047883513081418e+00</second>
+						<second>1.78511188071296734e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47714362103342944e+00</second>
+						<second>1.91896713840719335e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.97202889049760732e-01</second>
+						<second>2.29606310782487810e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.75259175642244802e+00</second>
+						<second>5.76348475399687366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.06292684541129434e+00</second>
+						<second>-1.50582241224448321e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01887458082588456e+00</second>
+						<second>2.01892103200676765e+00</second>
 					</item>
 				</goal_state>
-				<score>1.01962233075368225e+00</score>
+				<score>1.18116789935298006e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4209,34 +4209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.09620154082065557e+00</second>
+						<second>-1.66001060210170071e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.98375329317711313e+00</second>
+						<second>-2.49076505597975295e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91559557184099205e+00</second>
+						<second>1.50793965835930521e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.40832245063025785e+00</second>
+						<second>9.96926434887340007e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.15690091847424936e+00</second>
+						<second>-8.38227202844005426e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.98087400438522221e-01</second>
+						<second>5.79959983832688208e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70884723416629680e+00</second>
+						<second>1.70893290740777504e+00</second>
 					</item>
 				</goal_state>
-				<score>2.16363917186869026e+00</score>
+				<score>1.76210414020576717e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4299,34 +4299,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>4.08326642507211512e-01</second>
+						<second>1.91870821596405849e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.54174126536737655e+00</second>
+						<second>-1.28846132854674256e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91979981249692466e+00</second>
+						<second>-1.53949794722722633e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.11422712604884189e-01</second>
+						<second>2.76268182371672921e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.61387964598321343e+00</second>
+						<second>-2.90113972897780492e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19039311020277494e+00</second>
+						<second>-1.37798427304735371e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01047068608605883e+00</second>
+						<second>2.01035048636001967e+00</second>
 					</item>
 				</goal_state>
-				<score>1.20389165636935247e+00</score>
+				<score>1.34713349632555740e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4389,34 +4389,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>-1.76706926444106105e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>-1.31450197503233657e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>1.81103328666421470e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>2.39759722143401843e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>3.01363636487377962e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>-1.29499778414003064e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>-1.87152301946621979e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19656909145475421e+00</score>
+				<score>1.47347820299655624e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4479,34 +4479,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53022189292809441e+00</second>
+						<second>-1.62095553287975669e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.00453675309552048e-01</second>
+						<second>-2.54532344506961516e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.53906782089154004e+00</second>
+						<second>1.48788717770373102e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93747097344407226e+00</second>
+						<second>1.11784700081089516e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.97784685171257735e-01</second>
+						<second>-9.30123902517878465e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.73398684683231485e-01</second>
+						<second>4.33831835918449593e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55598097693302817e+00</second>
+						<second>1.55580556410467685e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95411140116671467e+00</score>
+				<score>1.92686814025049252e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4569,34 +4569,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.18713183411074397e+00</second>
+						<second>-1.02683492865521098e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.38116181756341971e+00</second>
+						<second>9.48674317627356101e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08599553174845975e+00</second>
+						<second>1.20088224591426762e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.05531775050922461e+00</second>
+						<second>-1.98589079176299754e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.29772050175647213e+00</second>
+						<second>-1.40755048225138357e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.97635756763170106e-02</second>
+						<second>-2.98521266683265818e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84173801460592257e+00</second>
+						<second>-1.84210059490522271e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22851116060931176e+00</score>
+				<score>1.28327350117975664e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4659,37 +4659,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24617260256913687e+00</second>
+						<second>1.72205248376110376e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.19512907685954972e-01</second>
+						<second>-2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37429292922704893e+00</second>
+						<second>-1.15123865146683757e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.27482608711207690e+00</second>
+						<second>8.67422664658528131e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.88429844779066480e+00</second>
+						<second>2.30853305890622273e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.65768377886834140e-01</second>
+						<second>-3.03268326116013487e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65797191107991382e+00</second>
+						<second>-1.65793155541261816e+00</second>
 					</item>
 				</goal_state>
-				<score>2.58109336219511309e+00</score>
+				<score>1.88452139690762188e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -4749,34 +4749,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.11191806911775615e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.28154620169855882e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91837906292681826e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.94827337503788156e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.25613033175391853e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.91594760289974397e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.27428871908445895e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.76889051357439486e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4839,34 +4839,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>4.74530017402023330e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>-1.05624800809902064e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>-1.91833769486716488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>-2.55157896840529208e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>1.62323194248382308e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>-1.82245614907201547e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>-1.44911334628091204e+00</second>
 					</item>
 				</goal_state>
-				<score>3.14754393971497981e+00</score>
+				<score>1.52429043014300103e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4929,37 +4929,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>1.91776545133462184e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>2.55897667859207845e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>1.09949135355929206e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>-2.55107756528358021e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>-5.40140460048449178e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>2.88521878756341899e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>1.49954117045562940e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03127993275650676e+00</score>
+				<score>1.97401244033585360e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -4979,6 +4979,96 @@
 						<item>7.11631238460540771e-01</item>
 						<item>-4.44718718528747559e-01</item>
 						<item>3.54105710983276367e-01</item>
+						<item>1.00000000000000000e+00</item>
+					</matrix>
+				</goal>
+				<seed_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</seed_state>
+				<goal_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>1.00937273420381080e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>-1.70682975890196498e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>-1.82039490036804441e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>2.33629930414074938e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>1.78071481358878514e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>3.09489111527005711e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>-1.13903674082585638e+00</second>
+					</item>
+				</goal_state>
+				<score>1.86391257513717629e-01</score>
+			</item>
+			<item>
+				<reached>0</reached>
+				<goal>
+					<matrix>
+						<count>16</count>
+						<item_version>0</item_version>
+						<item>8.28518629074096680e-01</item>
+						<item>-2.42612630128860474e-01</item>
+						<item>-5.04674136638641357e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>1.49011611252721584e-08</item>
+						<item>9.01265978813171387e-01</item>
+						<item>-4.33266699314117543e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>5.59961438179016113e-01</item>
+						<item>3.58969569206237904e-01</item>
+						<item>7.46715724468231201e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>7.43713676929473877e-01</item>
+						<item>-4.09646302461624146e-01</item>
+						<item>2.92791724205017090e-01</item>
 						<item>1.00000000000000000e+00</item>
 					</matrix>
 				</goal>
@@ -5054,96 +5144,6 @@
 					<matrix>
 						<count>16</count>
 						<item_version>0</item_version>
-						<item>8.28518629074096680e-01</item>
-						<item>-2.42612630128860474e-01</item>
-						<item>-5.04674136638641357e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>1.49011611252721584e-08</item>
-						<item>9.01265978813171387e-01</item>
-						<item>-4.33266699314117543e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>5.59961438179016113e-01</item>
-						<item>3.58969569206237904e-01</item>
-						<item>7.46715724468231201e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>7.43713676929473877e-01</item>
-						<item>-4.09646302461624146e-01</item>
-						<item>2.92791724205017090e-01</item>
-						<item>1.00000000000000000e+00</item>
-					</matrix>
-				</goal>
-				<seed_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-				</seed_state>
-				<goal_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
-					</item>
-				</goal_state>
-				<score>2.59969201292127350e+00</score>
-			</item>
-			<item>
-				<reached>1</reached>
-				<goal>
-					<matrix>
-						<count>16</count>
-						<item_version>0</item_version>
 						<item>4.49698954820632935e-01</item>
 						<item>-7.15381324291229248e-01</item>
 						<item>-5.34790217876434326e-01</item>
@@ -5199,34 +5199,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70199994554933620e+00</second>
+						<second>1.62494047894085369e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.86673637305314566e-01</second>
+						<second>-2.43513319174339493e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.69065797251037164e+00</second>
+						<second>1.74656690146476556e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.22100478856831218e+00</second>
+						<second>-1.09099663251552648e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.12448246350560477e-01</second>
+						<second>-7.68186185539359689e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.03931754589318626e+00</second>
+						<second>1.99052766000048553e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35092440724138330e-01</second>
+						<second>-9.34260289451639636e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74181647313376509e+00</score>
+				<score>1.93080934266989107e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5289,34 +5289,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53126048431065320e+00</second>
+						<second>7.81428035660315601e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.32988447033313850e-02</second>
+						<second>-1.26453765273216145e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02944222755326087e+00</second>
+						<second>-1.67674327982531790e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.25986323797174271e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.09080764483903891e+00</second>
+						<second>1.66532369915678502e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.07439863789472442e-01</second>
+						<second>2.46596639826576469e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08041676943324627e+00</second>
+						<second>-1.08013671542617651e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95229916239696610e+00</score>
+				<score>1.87880379487822380e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5379,34 +5379,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68623338654639876e+00</second>
+						<second>-1.72163284309378084e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13672185671777148e+00</second>
+						<second>-1.53916213208095592e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.90077331538778260e+00</second>
+						<second>1.20217488035764419e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.14255120062133653e+00</second>
+						<second>-2.21370694125508427e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.12555647535357983e-01</second>
+						<second>-8.74891570703069221e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01148211768354956e+00</second>
+						<second>-1.98323073941836459e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04538885910421775e+00</second>
+						<second>-1.04550040739439232e+00</second>
 					</item>
 				</goal_state>
-				<score>2.83182944725968921e+00</score>
+				<score>2.03315430877300696e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5469,34 +5469,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91937228003343208e+00</second>
+						<second>-1.27247526186191573e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.63324595204770096e-01</second>
+						<second>-1.28400746439163838e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55850303544677571e+00</second>
+						<second>1.91803540905574321e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.76985791397814207e+00</second>
+						<second>2.75447975472640927e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42066654841103945e+00</second>
+						<second>-1.14765098571166302e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.72494421280343602e+00</second>
+						<second>-4.11785431968862636e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.40714610734937740e-01</second>
+						<second>6.41623991924088921e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15705971834975507e+00</score>
+				<score>1.43744375528641249e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5586,7 +5586,7 @@
 						<second>-5.19108831883002164e-01</second>
 					</item>
 				</goal_state>
-				<score>1.62177808256003808e+00</score>
+				<score>1.10007763879719736e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5649,34 +5649,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>9.20944304263410118e-01</second>
+						<second>-1.06566595678115239e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.87021193683798059e+00</second>
+						<second>8.29576984680789220e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.23882836243211680e+00</second>
+						<second>-1.10487217521260495e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44358414718588746e+00</second>
+						<second>1.97458895094992704e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.72050173624956004e+00</second>
+						<second>1.80362482493112797e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.38587727624378054e+00</second>
+						<second>1.88361413758285967e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.90697043872218064e-01</second>
+						<second>7.90804399963784932e-01</second>
 					</item>
 				</goal_state>
-				<score>2.21201248455633959e+00</score>
+				<score>1.49970634219848242e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5739,34 +5739,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.33909822773381015e+00</second>
+						<second>-1.17027915403281590e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>5.95287661957896508e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.11318692844649303e+00</second>
+						<second>-1.16813868085955974e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.32811088996762661e+00</second>
+						<second>1.67272874221972856e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.09987838825157969e+00</second>
+						<second>1.89356441313338197e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11446869406191196e+00</second>
+						<second>2.12645327439734277e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.44076017974224935e-01</second>
+						<second>8.43411531465945496e-01</second>
 					</item>
 				</goal_state>
-				<score>2.62709874919048447e+00</score>
+				<score>1.64680654290055878e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5829,34 +5829,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.07306076028477393e+00</second>
+						<second>-1.15716293120337221e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30153318832618847e+00</second>
+						<second>-1.78904073923914320e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.74242218219127443e+00</second>
+						<second>-1.59806170499510602e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.89685476727776159e+00</second>
+						<second>-7.95781798047869415e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.26330784971510068e+00</second>
+						<second>1.87462253637191356e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.39665768813404978e-01</second>
+						<second>-4.77084791037538258e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.32979355276173772e-01</second>
+						<second>-6.32821576399394958e-01</second>
 					</item>
 				</goal_state>
-				<score>2.01923430819300753e+00</score>
+				<score>1.43337784012084968e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -7656,7 +7656,7 @@
 						<second>-4.70365871962010684e-01</second>
 					</item>
 				</goal_state>
-				<score>1.52984833760706862e+00</score>
+				<score>1.05355489870487234e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -7719,34 +7719,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20072493153391280e+00</second>
+						<second>-1.79531697620272390e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.29401653065134470e+00</second>
+						<second>-2.04678309838671391e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07585158687137894e+00</second>
+						<second>-1.14500901814729961e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.13214804831746640e+00</second>
+						<second>2.75610055038675261e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.79407525989134164e+00</second>
+						<second>-2.39659515213198571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83884112539327105e+00</second>
+						<second>-1.60982576195931926e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.81838582683084482e-01</second>
+						<second>-7.81600860156184574e-01</second>
 					</item>
 				</goal_state>
-				<score>2.19884513486316990e+00</score>
+				<score>1.65062087233926125e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -7899,34 +7899,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.33954212775196613e+00</second>
+						<second>1.27862387804412680e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.63776526730623795e+00</second>
+						<second>-2.96699991629540927e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.56618297028304876e-01</second>
+						<second>6.38800937032579119e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.20026433140506272e+00</second>
+						<second>1.68509481191374766e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.14176946023140680e+00</second>
+						<second>1.08410426040684538e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04532254286535986e+00</second>
+						<second>2.03014608835853805e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.41290489080106318e-01</second>
+						<second>4.40906139252821849e-01</second>
 					</item>
 				</goal_state>
-				<score>1.14608160239910362e+00</score>
+				<score>7.25238560375401631e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8016,7 +8016,7 @@
 						<second>-8.56682315444916354e-01</second>
 					</item>
 				</goal_state>
-				<score>1.71898122911505813e+00</score>
+				<score>1.11191298899378427e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8106,7 +8106,7 @@
 						<second>-1.08368232429619349e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05515147056394021e+00</score>
+				<score>1.33139548573366240e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8169,34 +8169,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.14320681441450644e-01</second>
+						<second>-7.15053901572165307e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.21401462915443181e+00</second>
+						<second>-1.40951410777398611e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.13945459719185282e-01</second>
+						<second>1.01731465736617999e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10228191777270146e+00</second>
+						<second>7.95700976521541703e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.51821173322463743e+00</second>
+						<second>1.65669040499026554e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.85256154446642274e+00</second>
+						<second>-1.74292059063927418e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19611045330668420e+00</second>
+						<second>-1.19612009105792372e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24990373148634282e+00</score>
+				<score>1.47162535854447635e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8259,34 +8259,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.45870603441779356e-01</second>
+						<second>-1.90040343858924121e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.46122563036105868e+00</second>
+						<second>-1.23773356184608940e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.22974281249460882e+00</second>
+						<second>-1.50019884491266864e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.96985428048774280e-01</second>
+						<second>-2.68725169147191600e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.61046744129876673e+00</second>
+						<second>-2.62960345012211416e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88590109267623518e+00</second>
+						<second>-1.18549598118165367e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20883022743746338e+00</second>
+						<second>-1.20883882864916337e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55008676467005557e+00</score>
+				<score>2.08697157554010609e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8349,34 +8349,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>7.40693320571234493e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>7.44091246611596868e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.91958482810070841e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>-9.47271132531224525e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>1.40140968668197075e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>2.11269808236268908e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>1.32217113581872869e+00</second>
 					</item>
 				</goal_state>
-				<score>3.19140182631580505e+00</score>
+				<score>1.64953766038609562e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8466,7 +8466,7 @@
 						<second>-9.66493235055629785e-01</second>
 					</item>
 				</goal_state>
-				<score>1.44793553589388080e+00</score>
+				<score>9.08662497803105762e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8556,7 +8556,7 @@
 						<second>-1.22569891005392995e+00</second>
 					</item>
 				</goal_state>
-				<score>1.33453264661056514e+00</score>
+				<score>8.36023495941651956e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8619,34 +8619,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78549015764916863e+00</second>
+						<second>-1.55539227767475885e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.46293251880433717e+00</second>
+						<second>-2.85148083581384437e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.42800006654786760e+00</second>
+						<second>1.57282428920260786e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.65816357110755286e+00</second>
+						<second>8.80080012165241010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.23470045172304665e-01</second>
+						<second>7.99631797348561379e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.78735868478040705e-01</second>
+						<second>-2.95885584774935428e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.44018062137717795e+00</second>
+						<second>1.43981037091917718e+00</second>
 					</item>
 				</goal_state>
-				<score>2.59094867134576878e+00</score>
+				<score>1.97463992841452607e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8709,34 +8709,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.87095544990829432e+00</second>
+						<second>-9.92617681711878697e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.41636129794093502e-01</second>
+						<second>3.83267030086647198e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46963317388807901e+00</second>
+						<second>1.75559652755160611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82734144918757835e+00</second>
+						<second>1.32437503451041017e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.43217179108098513e-01</second>
+						<second>1.26603382549877908e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.29524835396182381e+00</second>
+						<second>-8.31714952464826657e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59140227951450308e+00</second>
+						<second>1.59161523383490922e+00</second>
 					</item>
 				</goal_state>
-				<score>1.13296452432284789e+00</score>
+				<score>1.55678542383016844e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8799,34 +8799,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.22329817303393540e+00</second>
+						<second>-1.47469490641281542e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699994562407987e+00</second>
+						<second>-2.63595487332407430e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-5.19546296403588737e-01</second>
+						<second>-5.61628583861725539e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.00045882051722002e+00</second>
+						<second>2.19001397951012811e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.05507786343065835e+00</second>
+						<second>-2.53363988450875333e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35899340079208919e+00</second>
+						<second>-2.21092979638139431e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.67180783864624405e+00</second>
+						<second>-1.67187992425671150e+00</second>
 					</item>
 				</goal_state>
-				<score>2.30800279555373189e+00</score>
+				<score>1.50647332284202295e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8889,34 +8889,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64310920712857378e+00</second>
+						<second>-1.53173267786509387e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.79002321248350516e-01</second>
+						<second>-1.77282667143758466e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.59438959086294552e-01</second>
+						<second>1.60231310638154012e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.42961457148356019e-01</second>
+						<second>3.35787250540798998e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.12549311102825622e-01</second>
+						<second>1.67200630371206738e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.79013673728063072e-01</second>
+						<second>-1.92055797891331137e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.67054708124365980e+00</second>
+						<second>-1.67049630668899374e+00</second>
 					</item>
 				</goal_state>
-				<score>2.59320688934108201e+00</score>
+				<score>1.42250722506025440e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8979,34 +8979,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81045719926727888e+00</second>
+						<second>1.68783511367179195e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30966527110286446e+00</second>
+						<second>-2.78419906414459462e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.83321275907042613e+00</second>
+						<second>8.51610250722316775e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.31035737771082572e-01</second>
+						<second>2.34847610867647560e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.51858015219994202e-01</second>
+						<second>6.40917469279387308e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.22188927357438826e+00</second>
+						<second>6.12863254439794392e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70858620607624845e+00</second>
+						<second>1.70867173495133073e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55627350927667329e+00</score>
+				<score>1.72272674848483687e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9069,34 +9069,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59550989897317508e+00</second>
+						<second>-1.89231373273936865e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-8.82621141110014218e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44090100690636991e+00</second>
+						<second>-1.08962804336809405e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.32744234516445747e-01</second>
+						<second>3.03862464722657943e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.36307827840030971e+00</second>
+						<second>-2.97110621819475007e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.20229958993756864e-02</second>
+						<second>-8.30772212421785339e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49983264729218946e+00</second>
+						<second>-1.49989684307680471e+00</second>
 					</item>
 				</goal_state>
-				<score>2.99310541679632003e+00</score>
+				<score>1.71368223283239335e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9159,34 +9159,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>1.20525064133877313e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>1.06807647892408286e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>-2.05725454131995833e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>1.99935188095097427e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>3.14149997401605585e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>1.28802178645354082e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>1.66918845034099883e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88441433023030269e+00</score>
+				<score>7.24183348525726661e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9249,34 +9249,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.40812025799538287e+00</second>
+						<second>9.09779149139265830e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01258534261608313e+00</second>
+						<second>-2.59365792715854138e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.87057193789832221e-01</second>
+						<second>1.70626807983906792e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.33084864326910846e-01</second>
+						<second>1.17680115884579428e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.14016038200264802e+00</second>
+						<second>1.33521143855952795e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.12122734852228412e+00</second>
+						<second>-2.87516123702397453e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82014896173163843e+00</second>
+						<second>-1.82023478712049380e+00</second>
 					</item>
 				</goal_state>
-				<score>1.35321854611362369e+00</score>
+				<score>1.23439426517861120e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9339,34 +9339,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-4.36985859436715252e-01</second>
+						<second>1.73683108343406167e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.12979490990137910e+00</second>
+						<second>-1.81940614273005896e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.63789369143046737e+00</second>
+						<second>-1.30339813723883613e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10813012386253051e+00</second>
+						<second>3.14149999911816069e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.59615917663553630e+00</second>
+						<second>-1.40269544005628410e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.60188649476940470e-01</second>
+						<second>-1.27205318453978466e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91471087568719067e+00</second>
+						<second>1.91462557624244578e+00</second>
 					</item>
 				</goal_state>
-				<score>1.18088679828085308e+00</score>
+				<score>1.16547089670588522e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9429,34 +9429,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.32558736669130872e+00</second>
+						<second>3.56539030566210335e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999453984065e+00</second>
+						<second>-2.03599654813296871e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.68357323096353118e-01</second>
+						<second>1.85289353164450499e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23876761409588498e+00</second>
+						<second>8.23455558626131401e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.46789077008990620e-01</second>
+						<second>1.56887094003200311e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.10476713008028127e-01</second>
+						<second>-2.60508931285804657e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95027936317391948e+00</second>
+						<second>-1.95035624153060017e+00</second>
 					</item>
 				</goal_state>
-				<score>2.02700329454815265e+00</score>
+				<score>7.97963602488181989e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9519,34 +9519,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.79623416942807174e-01</second>
+						<second>-1.73719575743397536e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.29821330892276876e+00</second>
+						<second>1.84129867954716930e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-1.91774413376597508e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.80594517259085263e-01</second>
+						<second>6.26487220492402019e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.55443520857217576e+00</second>
+						<second>3.10249715823076322e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.07833171537881389e+00</second>
+						<second>-1.15478873422218342e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.92768107520861731e+00</second>
+						<second>1.92780097968912911e+00</second>
 					</item>
 				</goal_state>
-				<score>1.76470841609541473e+00</score>
+				<score>1.40035029532877914e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9609,34 +9609,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85619869990131159e+00</second>
+						<second>-8.53454204088713198e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.08288838404546217e-01</second>
+						<second>-2.47304437574942915e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.82127054171012870e-01</second>
+						<second>-5.17333958251786769e-02</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.27374566062601602e-01</second>
+						<second>-1.34519953557242489e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.57238206135825814e-01</second>
+						<second>1.06707580428323401e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.03951202183683988e+00</second>
+						<second>-1.80355365985413840e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68217647170056561e+00</second>
+						<second>1.68222527859290194e+00</second>
 					</item>
 				</goal_state>
-				<score>8.90812168949856487e-01</score>
+				<score>6.90690036310861871e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9699,34 +9699,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>9.79811942823496373e-02</second>
+						<second>-8.21351955174977610e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.14465271371399457e+00</second>
+						<second>8.26406029157641386e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.01047896702943873e-01</second>
+						<second>7.19144228890755965e-02</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.40055771767694681e-01</second>
+						<second>-1.19135958125385089e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.12618049584993907e+00</second>
+						<second>3.01177807509374595e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.16558072854845147e-03</second>
+						<second>-2.03948921582058684e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.84012434428012961e+00</second>
+						<second>1.84020847539761800e+00</second>
 					</item>
 				</goal_state>
-				<score>1.05705610778155812e+00</score>
+				<score>5.39066647966257861e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9789,37 +9789,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.06324610983759960e+00</second>
+						<second>1.62357078357623630e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.37494219794812711e+00</second>
+						<second>-1.39563908490548561e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.92003509174638942e-02</second>
+						<second>1.81503449356477775e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.18196382972099423e+00</second>
+						<second>-2.44332968557126895e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.13295584056993315e+00</second>
+						<second>5.95775671670709550e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27541616235289768e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99562017148508697e+00</second>
+						<second>1.99577343173699195e+00</second>
 					</item>
 				</goal_state>
-				<score>1.07888264301256531e+00</score>
+				<score>1.38335775728805926e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -9879,34 +9879,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-7.69376017263365908e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.82385151593207806e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-5.43516960440438957e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.35968476432216789e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.43827291456624895e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.03173042205581034e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.10125945200517306e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>5.06967067738273020e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9969,37 +9969,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85946368749034785e+00</second>
+						<second>1.34120750033892278e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.79791751606199601e+00</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.97362366978549297e-01</second>
+						<second>-4.72620734845622559e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.97620335507399969e-01</second>
+						<second>-7.33868344697108599e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52947768250495753e-01</second>
+						<second>-2.33657784429720339e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01323689057388489e+00</second>
+						<second>2.79106344882342039e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14038682548266790e+00</second>
+						<second>-2.14038674493232550e+00</second>
 					</item>
 				</goal_state>
-				<score>8.18727507093685247e-01</score>
+				<score>9.91088721313894278e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10059,37 +10059,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.20293245762891199e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.30286547418808274e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.31681426065307461e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.23252117161140218e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.88777799276001956e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.60377245850648309e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.10511499052358753e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>9.96310453651610278e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10149,37 +10149,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>9.37280139039612603e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.32265238770749116e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.97227850012231676e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.02083199503009103e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.54494514002340533e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.21762902290012898e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.96566239263256204e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>5.34874242777817685e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10239,34 +10239,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>7.19875864752295036e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.03008805015381122e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.61491763499105462e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.44875504563005153e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.49478360467695515e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>4.74889159987274156e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.12709338341328813e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>2.91922922159105133e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10329,34 +10329,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.08093954996353103e+00</second>
+						<second>8.18217859441243922e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.64439512907512964e-01</second>
+						<second>-1.48735439832291250e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26644433724732525e-01</second>
+						<second>-5.12775640813034395e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55676875357525102e+00</second>
+						<second>2.74156489674852200e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51015257952807280e+00</second>
+						<second>-1.48471131216827490e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.74704054822603494e-01</second>
+						<second>-2.08561978852388280e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24543665752652544e+00</second>
+						<second>2.24540886905348103e+00</second>
 					</item>
 				</goal_state>
-				<score>1.08406984480563962e+00</score>
+				<score>4.02178291897232754e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -10509,34 +10509,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.25077092712950733e-01</second>
+						<second>-1.01500707575439630e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.69790623811153374e+00</second>
+						<second>1.82366711237689638e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91979933927995750e+00</second>
+						<second>-1.38855853759464254e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.83516551080971357e+00</second>
+						<second>2.53888976952462420e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.37221475720566621e+00</second>
+						<second>-1.80256714177375454e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41926314378292839e+00</second>
+						<second>2.15660852280902215e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23615670605478734e+00</second>
+						<second>-2.23622349636829032e+00</second>
 					</item>
 				</goal_state>
-				<score>1.21471623246569083e+00</score>
+				<score>8.15661353700552066e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10599,34 +10599,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24400858352781674e+00</second>
+						<second>1.48352245942827787e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.00794230163967313e+00</second>
+						<second>1.49757467840579594e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.42386606328526266e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.32960376327118968e-01</second>
+						<second>6.67661306280757705e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.16492286900340658e+00</second>
+						<second>-6.95049954840599393e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20209079998456358e+00</second>
+						<second>1.68024568512709482e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19642123860076621e+00</second>
+						<second>-2.19645859546378297e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49011833835805363e+00</score>
+				<score>9.11750508839114376e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10689,34 +10689,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.60477486426728588e+00</second>
+						<second>-3.71737210413066843e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.42027186015603257e-01</second>
+						<second>7.10101028130124323e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40048434285221357e+00</second>
+						<second>-3.98432614590726986e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45756920258562817e+00</second>
+						<second>-2.83231086476938776e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.90548734895434202e-01</second>
+						<second>-8.37353335963813006e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.38153555537676764e+00</second>
+						<second>2.57320008678845680e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05338397701281306e+00</second>
+						<second>-2.05335491940663184e+00</second>
 					</item>
 				</goal_state>
-				<score>1.87313164443909197e+00</score>
+				<score>4.29471585666072325e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10779,34 +10779,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>6.32648198216742008e-01</second>
+						<second>7.84895567568886565e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.35593419478090071e-01</second>
+						<second>-8.88233979604194368e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75477249834014554e-01</second>
+						<second>2.98473147107647108e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39537372196105464e-01</second>
+						<second>2.60528095302436968e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.10942681408811533e-01</second>
+						<second>-1.86132652288998734e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.56848364001422352e-01</second>
+						<second>7.13419991602568859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19775669842247146e+00</second>
+						<second>2.19778890865752352e+00</second>
 					</item>
 				</goal_state>
-				<score>6.95799304744568858e-01</score>
+				<score>3.67444992061817591e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -11079,7 +11079,7 @@
 				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -11099,186 +11099,6 @@
 						<item>6.48891389369964600e-01</item>
 						<item>4.07772138714790344e-02</item>
 						<item>3.96672904491424561e-01</item>
-						<item>1.00000000000000000e+00</item>
-					</matrix>
-				</goal>
-				<seed_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-				</seed_state>
-				<goal_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>-1.76528754992648396e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>-2.19171237454950285e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>-1.25108377829169792e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>-2.72491677711839975e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>2.49193012835087568e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>-2.23265224736698809e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>-2.23355126590407460e+00</second>
-					</item>
-				</goal_state>
-				<score>1.50718223248924810e+00</score>
-			</item>
-			<item>
-				<reached>1</reached>
-				<goal>
-					<matrix>
-						<count>16</count>
-						<item_version>0</item_version>
-						<item>-1.45875990390777588e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.89303052425384521e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>1.22522432357071616e-02</item>
-						<item>-9.99923348426818848e-01</item>
-						<item>1.80663343053309331e-03</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.89227116107940674e-01</item>
-						<item>1.23847229406236371e-02</item>
-						<item>1.45864784717559814e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>5.54491102695465088e-01</item>
-						<item>-5.12911118566989899e-02</item>
-						<item>8.32926809787750244e-01</item>
-						<item>1.00000000000000000e+00</item>
-					</matrix>
-				</goal>
-				<seed_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-				</seed_state>
-				<goal_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>-4.12536375348701467e-01</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>-3.35354436364568367e-02</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>2.62672116812931677e-01</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>5.03023106022121191e-01</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>2.99103945834313301e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>2.65645996643270310e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>2.05199243548849442e+00</second>
-					</item>
-				</goal_state>
-				<score>6.52257570380298746e-01</score>
-			</item>
-			<item>
-				<reached>0</reached>
-				<goal>
-					<matrix>
-						<count>16</count>
-						<item_version>0</item_version>
-						<item>-1.63591369986534119e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.86528277397155762e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>1.34541541337965705e-02</item>
-						<item>-9.99907016754150391e-01</item>
-						<item>2.23103933967647942e-03</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.86436545848846436e-01</item>
-						<item>1.36378798633812626e-02</item>
-						<item>1.63576155900955200e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>5.67417979240417480e-01</item>
-						<item>-4.91383075714111328e-02</item>
-						<item>7.50992000102996826e-01</item>
 						<item>1.00000000000000000e+00</item>
 					</matrix>
 				</goal>
@@ -11347,6 +11167,186 @@
 					</item>
 				</goal_state>
 				<score>0.00000000000000000e+00</score>
+			</item>
+			<item>
+				<reached>0</reached>
+				<goal>
+					<matrix>
+						<count>16</count>
+						<item_version>0</item_version>
+						<item>-1.45875990390777588e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.89303052425384521e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>1.22522432357071616e-02</item>
+						<item>-9.99923348426818848e-01</item>
+						<item>1.80663343053309331e-03</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.89227116107940674e-01</item>
+						<item>1.23847229406236371e-02</item>
+						<item>1.45864784717559814e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>5.54491102695465088e-01</item>
+						<item>-5.12911118566989899e-02</item>
+						<item>8.32926809787750244e-01</item>
+						<item>1.00000000000000000e+00</item>
+					</matrix>
+				</goal>
+				<seed_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</seed_state>
+				<goal_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</goal_state>
+				<score>0.00000000000000000e+00</score>
+			</item>
+			<item>
+				<reached>1</reached>
+				<goal>
+					<matrix>
+						<count>16</count>
+						<item_version>0</item_version>
+						<item>-1.63591369986534119e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.86528277397155762e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>1.34541541337965705e-02</item>
+						<item>-9.99907016754150391e-01</item>
+						<item>2.23103933967647942e-03</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.86436545848846436e-01</item>
+						<item>1.36378798633812626e-02</item>
+						<item>1.63576155900955200e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>5.67417979240417480e-01</item>
+						<item>-4.91383075714111328e-02</item>
+						<item>7.50992000102996826e-01</item>
+						<item>1.00000000000000000e+00</item>
+					</matrix>
+				</goal>
+				<seed_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</seed_state>
+				<goal_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>6.95801773273192037e-01</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>-1.05691441023124288e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>-5.94899953691257477e-01</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>-4.06636108451582545e-01</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>1.38406853057464896e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>9.09915478419110468e-01</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>-2.19867963728287386e+00</second>
+					</item>
+				</goal_state>
+				<score>4.69702192593255477e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -11679,37 +11679,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91352435221176487e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.86907401090920078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-8.96409896699534081e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-3.09807034296986616e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-3.10552799571956850e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-1.50529702833704759e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.23340700035278505e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.64511223828612568e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -11769,34 +11769,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-7.20364087636914840e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.96527017431564222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76081404335145686e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.11746677285526141e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.39535061420177353e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.11646885968892162e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.96937793053254095e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>6.31704349372625013e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -11859,34 +11859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91469592883001671e+00</second>
+						<second>-9.10290306990677478e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.66598987233964246e+00</second>
+						<second>8.28281086330187821e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65696630181241367e+00</second>
+						<second>1.07963241839121565e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.62915004955622750e-01</second>
+						<second>7.81800176397839608e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.14149923267086484e+00</second>
+						<second>1.74094853531787241e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.09653242547718455e-01</second>
+						<second>2.38968751471141694e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12629894014469034e+00</second>
+						<second>2.12645894047616979e+00</second>
 					</item>
 				</goal_state>
-				<score>6.52315867476578992e-01</score>
+				<score>4.49877906090756716e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -11949,34 +11949,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78251176099799391e+00</second>
+						<second>-8.88297507651151452e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.19489238988229673e+00</second>
+						<second>-1.79429232570836450e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.24313199455754897e+00</second>
+						<second>-3.60844303858643578e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.85906965658484014e+00</second>
+						<second>-2.66304084548964504e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.71302138200440068e-01</second>
+						<second>1.53062598549116058e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67606665185651682e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598222712090623e+00</second>
+						<second>-2.24596080793392971e+00</second>
 					</item>
 				</goal_state>
-				<score>1.36893879494514903e+00</score>
+				<score>3.32237146478462711e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -12129,34 +12129,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82144546480838221e+00</second>
+						<second>7.19505676339486255e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.57843304201246459e+00</second>
+						<second>-1.44279526354930687e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.99837885856917397e-01</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.66030430629205894e-01</second>
+						<second>3.05305505930143661e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.10585614454091274e+00</second>
+						<second>1.76630609047282761e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.35230579294670794e-01</second>
+						<second>1.72148399085468817e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23426143576271397e+00</second>
+						<second>-2.23432563890752700e+00</second>
 					</item>
 				</goal_state>
-				<score>1.42604841400662385e+00</score>
+				<score>7.69523236060894039e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12219,34 +12219,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74851762123866439e+00</second>
+						<second>-8.37996479957762053e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.44848180349166256e-01</second>
+						<second>1.49920815009164476e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.18977104702790148e-01</second>
+						<second>1.91970493483758142e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.88784524483641847e-01</second>
+						<second>-2.47556878669857694e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54724794725825099e+00</second>
+						<second>-1.29967136466343969e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.90066797114521879e+00</second>
+						<second>-1.67708101148356992e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19434632166903887e+00</second>
+						<second>-2.19438208745307639e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64272314118825014e+00</score>
+				<score>7.66320484105000588e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12309,34 +12309,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>3.02999424606095191e-01</second>
+						<second>-1.86416171478050186e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.21116522803929483e+00</second>
+						<second>8.95444834583515092e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.91146657947240883e-01</second>
+						<second>9.96455300924481424e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.39187157337104894e+00</second>
+						<second>4.07169608229949187e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.18050830717761990e+00</second>
+						<second>1.46499229156824035e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.31464350069013070e+00</second>
+						<second>1.01991223496223871e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68375817095982816e+00</second>
+						<second>1.68406514677942565e+00</second>
 					</item>
 				</goal_state>
-				<score>4.60724348181056287e-01</score>
+				<score>1.45371394390367531e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12399,37 +12399,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-7.51548989187909994e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>2.02103896661429161e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>7.49472030307222314e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-1.98139926514136255e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>-2.46418980184020597e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>-1.83798535134854690e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53933438727767591e+00</score>
+				<score>8.83338974738492044e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -12489,34 +12489,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>6.55677827412214365e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.76256127413466146e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.41033827544262080e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.18767299493333933e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.54781488493741604e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.25406051802352048e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.99619245045633020e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>8.37078837411171783e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12579,34 +12579,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.86306013661689018e+00</second>
+						<second>-1.90509089002319643e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.31555036379148182e+00</second>
+						<second>9.37905573316270225e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76620201265967802e+00</second>
+						<second>1.66576255842348075e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.34746571828046957e-01</second>
+						<second>-2.25842274907401053e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.14150000000000018e+00</second>
+						<second>8.34269476046092667e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.01251336101051170e-01</second>
+						<second>8.54707547956793268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10305986174241832e+00</second>
+						<second>2.10305163386111049e+00</second>
 					</item>
 				</goal_state>
-				<score>1.07484775167085500e+00</score>
+				<score>1.19927116066640041e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12669,34 +12669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-5.02933939120992934e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.45520909706309198e+00</second>
+						<second>-1.29858899524431726e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42561763890709092e+00</second>
+						<second>-1.63322047923810909e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.08079006401035649e+00</second>
+						<second>3.03417317283493704e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86150675388135323e+00</second>
+						<second>1.57564592072330623e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48195571929522618e+00</second>
+						<second>-1.41804503933952475e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.14088621192486928e+00</second>
+						<second>-2.14110226212126031e+00</second>
 					</item>
 				</goal_state>
-				<score>7.11054609667531978e-01</score>
+				<score>9.39611736160789468e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12759,37 +12759,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>6.10393588345254701e-01</second>
+						<second>1.75725339769834421e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.65612469265564077e+00</second>
+						<second>-1.69184079315462532e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.56689847327008436e+00</second>
+						<second>1.83278826348029189e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.44881187582345428e+00</second>
+						<second>-5.20836210584842974e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.54030338323398097e+00</second>
+						<second>2.83296966030350594e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.90944161727414397e-01</second>
+						<second>-1.85868664918985305e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09843802742846375e+00</second>
+						<second>-2.09845339427815514e+00</second>
 					</item>
 				</goal_state>
-				<score>1.34465343350406452e+00</score>
+				<score>1.14329505747901711e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -12849,34 +12849,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.06647917196091280e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.74914485997576463e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.10466481717867354e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.79882378782119434e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.62614644885783255e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.45437943337719622e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.49541221080352438e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.02732082669698577e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12939,34 +12939,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.47334217786541072e-01</second>
+						<second>1.00320691767083425e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.27446970301488660e+00</second>
+						<second>2.31628361045562253e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.09717177215068751e-01</second>
+						<second>-1.17948258519429944e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.73292652011883552e-01</second>
+						<second>-1.87179418179828461e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.20971240044646478e+00</second>
+						<second>2.03099065944267698e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.63641767018996598e+00</second>
+						<second>-1.20172905134768304e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.66854555579049957e+00</second>
+						<second>1.66838034050747064e+00</second>
 					</item>
 				</goal_state>
-				<score>1.15973667927079260e+00</score>
+				<score>1.06302744047292411e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13029,37 +13029,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.17537219334189244e-01</second>
+						<second>-1.18066876320626998e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.33225099638150302e+00</second>
+						<second>-1.33262220850533120e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.89898807131624037e-01</second>
+						<second>-9.89489091833963608e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.18256854455601079e+00</second>
+						<second>-2.18078189264411382e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.84794542458285771e+00</second>
+						<second>1.29353465213611218e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.17165088847298075e-03</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82322472617352060e+00</second>
+						<second>-1.82326083414258866e+00</second>
 					</item>
 				</goal_state>
-				<score>9.80025407988013741e-01</score>
+				<score>6.11739558512857454e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -13119,34 +13119,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.64791341378043343e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.19121384852649337e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-6.46481234925323278e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>7.03777123186843490e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.14101031668235819e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.08168794078154962e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91953338305842314e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.02347058026250270e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13209,34 +13209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.05721340791645391e+00</second>
+						<second>-1.87778184537552462e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.64615886293791847e-01</second>
+						<second>1.91035682884637015e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.94753847444241845e-01</second>
+						<second>-9.85576688837575654e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.14604589264162104e+00</second>
+						<second>-2.76628044336025658e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.76977077355334411e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.03046174609780583e-01</second>
+						<second>2.02673101427045355e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95456772673586676e+00</second>
+						<second>-1.95454002722579179e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64875130428336081e+00</score>
+				<score>1.26516030456824580e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13299,34 +13299,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.05415414840773258e+00</second>
+						<second>1.69299874270690237e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.68286993160049647e-01</second>
+						<second>1.84193510922329673e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.80312776913066397e-01</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.04588550235985500e+00</second>
+						<second>2.96501464852501329e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.75180910224192932e+00</second>
+						<second>1.55285150090577351e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.09555641718059560e+00</second>
+						<second>2.07426177794744149e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91966717825427602e+00</second>
+						<second>1.91958012188061611e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85747025971997504e+00</score>
+				<score>1.11717476966528520e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13416,7 +13416,7 @@
 						<second>-9.49982184898873983e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45194105736802337e+00</score>
+				<score>9.11314885644125133e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13506,10 +13506,10 @@
 						<second>-1.22673386703047549e+00</second>
 					</item>
 				</goal_state>
-				<score>1.34156517519893592e+00</score>
+				<score>8.39987522698944916e-02</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -13569,34 +13569,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.34683106325378366e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45080340402996599e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42302492641022194e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.69475089787046751e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63511101101506995e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.07067376882463416e-02</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44352668438038667e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11957053164731235e+00</score>
+				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13659,34 +13659,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82811590160520149e-01</second>
+						<second>1.60954317770874344e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.22211893834976681e+00</second>
+						<second>-1.18876251804851951e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.23735562482829686e+00</second>
+						<second>-6.34701495905016011e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.78322918217369475e-01</second>
+						<second>-2.33907602161487249e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.75570349305915130e+00</second>
+						<second>2.91965743708363012e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.52581470086365423e+00</second>
+						<second>-1.31464782418770310e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.60006610246032666e+00</second>
+						<second>1.60013386182524897e+00</second>
 					</item>
 				</goal_state>
-				<score>1.98728467407406151e+00</score>
+				<score>1.28603503079732590e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13749,34 +13749,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88894948610890689e+00</second>
+						<second>9.18342037309730214e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.47291741641090090e+00</second>
+						<second>-1.32468694347282101e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.04875410507604117e+00</second>
+						<second>-1.37529146519120249e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.51210569581088206e-01</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98090273040947062e+00</second>
+						<second>1.41035295655502413e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.67231445101913789e+00</second>
+						<second>-1.79847105036674515e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68114663753351978e+00</second>
+						<second>-1.68114134795766001e+00</second>
 					</item>
 				</goal_state>
-				<score>8.13935591314412288e-01</score>
+				<score>1.43159783704592453e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13839,37 +13839,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>1.80806532153444027e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.92911340802956710e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.73772997939578810e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-2.31860631379363147e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-1.63413150336973390e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>-2.26755002117505766e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>-1.68208725295755523e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>1.06681427014492194e-01</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -13929,34 +13929,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.43531533341674100e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699999895045297e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.24161438423364756e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02495383146078023e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.13502663847101504e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.17552425847183606e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.71099402716718441e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</goal_state>
-				<score>2.65120303324593865e+00</score>
+				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -14109,34 +14109,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20745073150342641e+00</second>
+						<second>1.03074133591130912e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13032902988282702e-01</second>
+						<second>-1.49222945101483329e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.46000430311595153e-01</second>
+						<second>-8.36963732463242849e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.76351007765264889e+00</second>
+						<second>-3.14142845289367623e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.95414486358020634e+00</second>
+						<second>1.74493898536790959e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.09953861589609536e+00</second>
+						<second>-2.27907504280447126e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.26303072667013672e-01</second>
+						<second>-4.26323613797513157e-01</second>
 					</item>
 				</goal_state>
-				<score>1.08375260986259425e+00</score>
+				<score>7.27497097094416262e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14226,7 +14226,7 @@
 						<second>-8.50023767214708625e-01</second>
 					</item>
 				</goal_state>
-				<score>1.72899999903284129e+00</score>
+				<score>1.11924565096935422e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14289,34 +14289,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.35846196772126260e-01</second>
+						<second>-7.33901691195290473e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72923431885260293e+00</second>
+						<second>-1.72414104515392852e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.78285933025091725e-01</second>
+						<second>-8.80810977468605261e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.18392825213203357e-01</second>
+						<second>-7.11344168677512712e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.47835364169193872e+00</second>
+						<second>1.47784760118987268e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.49246547005148122e+00</second>
+						<second>1.48907481213217308e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.07734173969160318e+00</second>
+						<second>-1.07731968164829972e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05627177806386241e+00</score>
+				<score>1.33293586607232700e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14379,34 +14379,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.50764850372115289e-01</second>
+						<second>6.70937992616070566e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12224267863576088e+00</second>
+						<second>-1.62830358103941975e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44014993514386958e+00</second>
+						<second>-1.07717955556017086e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.45367801645884165e-01</second>
+						<second>2.50968568674120895e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.56653484220546546e+00</second>
+						<second>1.47952276203538435e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.29569494602203616e-01</second>
+						<second>-1.48997801055547052e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18864726815016164e+00</second>
+						<second>-1.18858030622541477e+00</second>
 					</item>
 				</goal_state>
-				<score>2.73133918641017948e+00</score>
+				<score>1.52944900373906456e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14469,34 +14469,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.09644641267873744e+00</second>
+						<second>-1.82665184660278501e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90709143515057900e+00</second>
+						<second>2.23860910816237579e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88007332498985003e+00</second>
+						<second>-9.42800783830380684e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.41207580126073617e+00</second>
+						<second>-2.47806899298181671e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.97008951184641012e+00</second>
+						<second>2.53909863493277088e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36471025539712709e+00</second>
+						<second>1.87089759702806080e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22481227975414475e+00</second>
+						<second>-1.22492230954364767e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88153760331429387e+00</score>
+				<score>1.87442833140864962e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14559,34 +14559,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>5.68177011246680075e-01</second>
+						<second>-6.58905491749907979e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.46705570330263479e+00</second>
+						<second>2.25448695813449396e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.50496966648867381e+00</second>
+						<second>1.85584794676184361e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.75612215870060329e+00</second>
+						<second>7.68678699340953453e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.53083553538697004e+00</second>
+						<second>-1.46507066950058884e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25873611394319540e+00</second>
+						<second>1.11517403524397496e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.32825124744527723e+00</second>
+						<second>-1.32803278138942438e+00</second>
 					</item>
 				</goal_state>
-				<score>2.76747091606945883e+00</score>
+				<score>1.65832630251341234e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -15216,7 +15216,7 @@
 						<second>-4.78444509154321407e-01</second>
 					</item>
 				</goal_state>
-				<score>1.55624495744348335e+00</score>
+				<score>1.06751194480851699e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -15279,34 +15279,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.11667008859073280e+00</second>
+						<second>-1.75648834752249239e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.05267552672379683e+00</second>
+						<second>1.13384291142835281e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.14334940209197855e+00</second>
+						<second>1.47422122628212149e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.24296277159568813e+00</second>
+						<second>-5.85059951236873377e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.40026690323890368e+00</second>
+						<second>-7.36370107472677726e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.78704396574746771e+00</second>
+						<second>1.22086034918793662e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85440494025856029e-01</second>
+						<second>7.85689592388231550e-01</second>
 					</item>
 				</goal_state>
-				<score>2.20534704087316991e+00</score>
+				<score>1.73532611887911109e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17169,34 +17169,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.02239393200333573e+00</second>
+						<second>-1.27519319973097711e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.09675499208434424e+00</second>
+						<second>2.09268350498847955e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.60752843186195760e-01</second>
+						<second>9.85837731090586034e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56137765089082547e+00</second>
+						<second>1.35852496946961776e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.38704429811137997e+00</second>
+						<second>1.12510813824281297e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21347834869695603e+00</second>
+						<second>-5.32115018628246284e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.56078498803381693e-01</second>
+						<second>4.55167037174524503e-01</second>
 					</item>
 				</goal_state>
-				<score>1.06704945248320615e+00</score>
+				<score>8.43615784220354270e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17529,34 +17529,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36900613459642884e+00</second>
+						<second>-1.36868237237873669e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.10054277472041995e+00</second>
+						<second>1.09870241476746688e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.30678754922522256e-01</second>
+						<second>5.30364901983272463e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23149765602646122e+00</second>
+						<second>2.22997403861568921e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.62751067478911082e-01</second>
+						<second>7.63050578799813306e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.67112741878443671e-01</second>
+						<second>-8.67445348706556096e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.69185498819668423e-01</second>
+						<second>-4.69196745664701986e-01</second>
 					</item>
 				</goal_state>
-				<score>9.90334509156620690e-01</score>
+				<score>6.21974315556202834e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -17646,7 +17646,7 @@
 						<second>-9.53265930081534374e-01</second>
 					</item>
 				</goal_state>
-				<score>1.29321995058293049e+00</score>
+				<score>8.11832485201464532e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -17709,34 +17709,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.66798647272637268e-01</second>
+						<second>-6.52010225407641864e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.72431268683445249e+00</second>
+						<second>1.69610213533389076e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.58109736429890224e-01</second>
+						<second>-4.72966263552039912e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.01832117499245878e+00</second>
+						<second>9.84110912576335761e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.26782186111032491e+00</second>
+						<second>-1.26314581140089599e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.36313649066559517e+00</second>
+						<second>-1.34791286948033018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22304121682652300e+00</second>
+						<second>-1.22312204452842344e+00</second>
 					</item>
 				</goal_state>
-				<score>1.14620276667101928e+00</score>
+				<score>7.31268041635712851e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17979,34 +17979,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.31222720248733404e+00</second>
+						<second>-1.31343594033486655e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.27939713425300061e+00</second>
+						<second>1.28290337245760933e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>3.13593709603682047e-01</second>
+						<second>3.14639750308510269e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.93065620454844744e+00</second>
+						<second>1.93306059877373260e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.31516491632137417e-01</second>
+						<second>2.30611026632064370e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00115465142979798e+00</second>
+						<second>-1.00060318530160286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.52424988756112945e-01</second>
+						<second>-8.52343077423828976e-01</second>
 					</item>
 				</goal_state>
-				<score>1.01911012761702491e+00</score>
+				<score>6.39334216125384269e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18096,7 +18096,7 @@
 						<second>-1.21418603397266978e+00</second>
 					</item>
 				</goal_state>
-				<score>7.70497660753122871e-01</score>
+				<score>4.83156129531325806e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18159,34 +18159,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.00729730701534459e-01</second>
+						<second>-4.41376246051826238e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52926993072476214e+00</second>
+						<second>1.36520657641026433e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.55109522760630569e-01</second>
+						<second>-5.08242549674962185e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24550351963730610e+00</second>
+						<second>9.13853049729421052e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.04228057592113643e+00</second>
+						<second>-1.08765952088478568e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.52207577790875392e+00</second>
+						<second>-1.35161082698479951e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42467377967943376e+00</second>
+						<second>-1.42470573906227327e+00</second>
 					</item>
 				</goal_state>
-				<score>7.08426971080675205e-01</score>
+				<score>6.32423090565556040e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -18339,34 +18339,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20844229047349394e+00</second>
+						<second>-1.21403243616700629e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.17851646990905312e+00</second>
+						<second>1.20395327074918468e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>2.27675825883978167e-01</second>
+						<second>2.32154446918140273e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.67270972823862119e+00</second>
+						<second>1.69002996327717359e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.09966975277338624e-01</second>
+						<second>2.02121513840208933e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.82664612132685589e-01</second>
+						<second>-6.81996196375069585e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.74659886955450006e-01</second>
+						<second>-5.74658866428516046e-01</second>
 					</item>
 				</goal_state>
-				<score>5.86601011777236336e-01</score>
+				<score>3.67969113329893460e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18456,7 +18456,7 @@
 						<second>-1.04797774705633229e+00</second>
 					</item>
 				</goal_state>
-				<score>2.62494227858325380e-01</score>
+				<score>1.64595201703464124e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18546,7 +18546,7 @@
 						<second>-1.37496471700331924e+00</second>
 					</item>
 				</goal_state>
-				<score>7.86967415368791889e-01</score>
+				<score>4.92865475818263440e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18609,34 +18609,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.80506681849162920e-01</second>
+						<second>2.28884946147126234e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.94011491471235320e-01</second>
+						<second>9.62021258986740291e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02565167140924340e-01</second>
+						<second>7.56618227918357533e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.76477319031719060e+00</second>
+						<second>-9.98729964421514516e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.22088887165023285e+00</second>
+						<second>1.94445131941122029e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.64599808909673384e+00</second>
+						<second>-2.81611457160342393e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.62534859529353226e+00</second>
+						<second>1.62516576307562688e+00</second>
 					</item>
 				</goal_state>
-				<score>1.30900756946279162e+00</score>
+				<score>6.52806541036227012e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18699,34 +18699,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-3.26975925070714379e-02</second>
+						<second>2.84846765273686700e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.12200247567090949e+00</second>
+						<second>1.01406969580029749e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.13566706992761945e-01</second>
+						<second>-6.33415283595262335e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55200880544277497e+00</second>
+						<second>3.03281076371943514e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.10525654690664643e+00</second>
+						<second>-1.05736493200160719e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07519763668234880e+00</second>
+						<second>-8.44554401359051687e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.79449588827544604e+00</second>
+						<second>-1.79453269022787953e+00</second>
 					</item>
 				</goal_state>
-				<score>1.02536971506614227e+00</score>
+				<score>7.58592035870612191e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -18906,7 +18906,7 @@
 						<second>-7.55559935905880442e-01</second>
 					</item>
 				</goal_state>
-				<score>4.66252715399525564e-01</score>
+				<score>2.92538735875215658e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18996,7 +18996,7 @@
 						<second>-1.18056840380282213e+00</second>
 					</item>
 				</goal_state>
-				<score>7.46025382331469644e-01</score>
+				<score>4.67530065122002195e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19059,37 +19059,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-2.61846131516187797e-01</second>
+						<second>-2.61749814334796604e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.03539548310551655e-01</second>
+						<second>7.03792455220239366e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.65448695577726634e-01</second>
+						<second>-3.65634016554952757e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.27573383576829724e-01</second>
+						<second>4.26282726016538549e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.20130853540393434e-01</second>
+						<second>-6.20763564229138920e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.40176747195391194e-01</second>
+						<second>-6.39232254173879966e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.49752420075291481e+00</second>
+						<second>-1.49751094457082190e+00</second>
 					</item>
 				</goal_state>
-				<score>8.80196856586717979e-01</score>
+				<score>5.51936395446018593e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -19109,6 +19109,96 @@
 						<item>5.40178596973419189e-01</item>
 						<item>1.49183779954910278e-01</item>
 						<item>9.49210345745086670e-01</item>
+						<item>1.00000000000000000e+00</item>
+					</matrix>
+				</goal>
+				<seed_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>0.00000000000000000e+00</second>
+					</item>
+				</seed_state>
+				<goal_state>
+					<count>7</count>
+					<item_version>0</item_version>
+					<item>
+						<first>joint_b</first>
+						<second>1.78582323721482202e-02</second>
+					</item>
+					<item>
+						<first>joint_e</first>
+						<second>-2.32221365582043227e+00</second>
+					</item>
+					<item>
+						<first>joint_l</first>
+						<second>4.86490826813040955e-01</second>
+					</item>
+					<item>
+						<first>joint_r</first>
+						<second>2.78353998450307305e+00</second>
+					</item>
+					<item>
+						<first>joint_s</first>
+						<second>2.29243069765892038e+00</second>
+					</item>
+					<item>
+						<first>joint_t</first>
+						<second>-3.14150000000000018e+00</second>
+					</item>
+					<item>
+						<first>joint_u</first>
+						<second>-1.74774775322851905e+00</second>
+					</item>
+				</goal_state>
+				<score>6.09188286707996393e-02</score>
+			</item>
+			<item>
+				<reached>0</reached>
+				<goal>
+					<matrix>
+						<count>16</count>
+						<item_version>0</item_version>
+						<item>-1.41825169324874878e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.89891827106475830e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>-3.19198071956635701e-02</item>
+						<item>-9.99479949474334717e-01</item>
+						<item>-4.57325950264932460e-03</item>
+						<item>0.00000000000000000e+00</item>
+						<item>9.89377081394195557e-01</item>
+						<item>-3.22457514703275022e-02</item>
+						<item>1.41751423478126526e-01</item>
+						<item>0.00000000000000000e+00</item>
+						<item>5.48199594020843506e-01</item>
+						<item>1.35252058506011963e-01</item>
+						<item>8.89547824859619141e-01</item>
 						<item>1.00000000000000000e+00</item>
 					</matrix>
 				</goal>
@@ -19177,96 +19267,6 @@
 					</item>
 				</goal_state>
 				<score>0.00000000000000000e+00</score>
-			</item>
-			<item>
-				<reached>1</reached>
-				<goal>
-					<matrix>
-						<count>16</count>
-						<item_version>0</item_version>
-						<item>-1.41825169324874878e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.89891827106475830e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>-3.19198071956635701e-02</item>
-						<item>-9.99479949474334717e-01</item>
-						<item>-4.57325950264932460e-03</item>
-						<item>0.00000000000000000e+00</item>
-						<item>9.89377081394195557e-01</item>
-						<item>-3.22457514703275022e-02</item>
-						<item>1.41751423478126526e-01</item>
-						<item>0.00000000000000000e+00</item>
-						<item>5.48199594020843506e-01</item>
-						<item>1.35252058506011963e-01</item>
-						<item>8.89547824859619141e-01</item>
-						<item>1.00000000000000000e+00</item>
-					</matrix>
-				</goal>
-				<seed_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
-					</item>
-				</seed_state>
-				<goal_state>
-					<count>7</count>
-					<item_version>0</item_version>
-					<item>
-						<first>joint_b</first>
-						<second>1.91940628658525037e+00</second>
-					</item>
-					<item>
-						<first>joint_e</first>
-						<second>2.96674194941214386e+00</second>
-					</item>
-					<item>
-						<first>joint_l</first>
-						<second>-1.42817170581761199e+00</second>
-					</item>
-					<item>
-						<first>joint_r</first>
-						<second>-2.83517530433795795e+00</second>
-					</item>
-					<item>
-						<first>joint_s</first>
-						<second>-2.88034355431886580e+00</second>
-					</item>
-					<item>
-						<first>joint_t</first>
-						<second>3.10487283854936225e+00</second>
-					</item>
-					<item>
-						<first>joint_u</first>
-						<second>1.88864534077426671e+00</second>
-					</item>
-				</goal_state>
-				<score>5.26608283706936020e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -19446,7 +19446,7 @@
 						<second>-8.39899720692192098e-01</second>
 					</item>
 				</goal_state>
-				<score>6.42154842556137972e-01</score>
+				<score>4.03132401593474382e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19536,7 +19536,7 @@
 						<second>-1.23898098377235000e+00</second>
 					</item>
 				</goal_state>
-				<score>8.54961841900390929e-01</score>
+				<score>5.35545650913152940e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19626,7 +19626,7 @@
 						<second>-1.54869863850556344e+00</second>
 					</item>
 				</goal_state>
-				<score>8.25802757844167457e-01</score>
+				<score>5.17261324121935234e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19689,37 +19689,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91008981549870804e+00</second>
+						<second>4.09424902917382080e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.11906462898043813e-02</second>
+						<second>3.45456857225476310e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.29022314050032327e+00</second>
+						<second>3.48978913735986940e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.06042741301653654e-01</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74557603574861475e-01</second>
+						<second>2.78964900530003668e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96396093409975825e-01</second>
+						<second>-1.18477591876431712e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80295331768923406e+00</second>
+						<second>1.80296314770116961e+00</second>
 					</item>
 				</goal_state>
-				<score>5.48412408099122728e-01</score>
+				<score>4.57074116312059381e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -19779,34 +19779,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.66184242357484124e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.21552590947049000e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.40935083399082905e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.67911438377613287e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.34381253992498717e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.02284130522082606e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.95468459237076653e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>4.20178687996265246e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -19986,7 +19986,7 @@
 						<second>-8.38054324324180144e-01</second>
 					</item>
 				</goal_state>
-				<score>6.40240909362604249e-01</score>
+				<score>4.01860301448655824e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20076,7 +20076,7 @@
 						<second>-1.24409705782452895e+00</second>
 					</item>
 				</goal_state>
-				<score>8.56441736951577215e-01</score>
+				<score>5.36431946849181412e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20166,7 +20166,7 @@
 						<second>-1.54369589496593007e+00</second>
 					</item>
 				</goal_state>
-				<score>8.27855265452758893e-01</score>
+				<score>5.18482590808771043e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20229,34 +20229,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-5.04226650346596417e-01</second>
+						<second>3.73047572042616501e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69029813872833712e+00</second>
+						<second>2.79382224352430164e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.76013792203408637e-01</second>
+						<second>3.48514383225936863e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.32509403910974144e+00</second>
+						<second>1.96343516434320270e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.39270025665403296e-01</second>
+						<second>-2.79449846781042588e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.59151188230410967e+00</second>
+						<second>-7.80966472600948675e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79948640577291719e+00</second>
+						<second>-1.79915588272415383e+00</second>
 					</item>
 				</goal_state>
-				<score>7.20010521341616139e-01</score>
+				<score>4.48748793815922434e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20319,34 +20319,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.13672789636050098e+00</second>
+						<second>-1.29701992839008162e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.77564591904000868e-01</second>
+						<second>2.53490776245480420e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02276528436802150e+00</second>
+						<second>-1.12358782810495961e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.15530268270667991e+00</second>
+						<second>-9.25833141315268726e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.86244516319016862e+00</second>
+						<second>2.01546148809896808e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.15239187742108684e+00</second>
+						<second>-1.03185827778537220e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.95359200540472422e+00</second>
+						<second>1.95352047743055546e+00</second>
 					</item>
 				</goal_state>
-				<score>1.57050017887173676e+00</score>
+				<score>1.10654810778406332e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -20499,34 +20499,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.74627680459134416e-01</second>
+						<second>-8.74771718964630352e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.83354298683794137e-01</second>
+						<second>-7.79443465540209157e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-2.48784214042306398e-02</second>
+						<second>-2.47653103952648716e-02</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.16083336000819726e-01</second>
+						<second>-8.16651673574029791e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15932951163061715e-01</second>
+						<second>2.11569208717697216e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29719986256698472e-01</second>
+						<second>5.29936119276946394e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.45811391837392534e-01</second>
+						<second>-7.45809599036838633e-01</second>
 					</item>
 				</goal_state>
-				<score>4.66317236636630161e-01</score>
+				<score>2.93944839813112431e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20616,7 +20616,7 @@
 						<second>-1.18278805510680551e+00</second>
 					</item>
 				</goal_state>
-				<score>7.48770661878149113e-01</score>
+				<score>4.69229997012265698e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20706,7 +20706,7 @@
 						<second>-1.48694600446771652e+00</second>
 					</item>
 				</goal_state>
-				<score>8.77710339492713598e-01</score>
+				<score>5.49969195594879473e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20769,37 +20769,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.44874978693728482e-02</second>
+						<second>-1.89546115483789301e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.23056269840525045e-01</second>
+						<second>-2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.85296749900965330e-01</second>
+						<second>1.31665810193299793e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14149999826592419e+00</second>
+						<second>2.80775921288649322e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.46679858713947908e-01</second>
+						<second>-3.09555641159509176e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.78418431258152532e+00</second>
+						<second>2.69728137160487776e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75001536927578494e+00</second>
+						<second>-1.75000046711948376e+00</second>
 					</item>
 				</goal_state>
-				<score>1.03324961983299835e+00</score>
+				<score>1.62990130274630080e-01</score>
 			</item>
 			<item>
-				<reached>1</reached>
+				<reached>0</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -20859,34 +20859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43913354627744322e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.38759444565720935e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.57867141684112855e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.80199742905214988e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.15620009994681983e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89059260775855376e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</goal_state>
-				<score>8.26991592064219017e-01</score>
+				<score>0.00000000000000000e+00</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -21066,7 +21066,7 @@
 						<second>-5.68937363132413165e-01</second>
 					</item>
 				</goal_state>
-				<score>5.83060435609753513e-01</score>
+				<score>3.65393272450833528e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21156,7 +21156,7 @@
 						<second>-1.06034486684173679e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77367013846041954e-01</score>
+				<score>1.73930091161937361e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21246,7 +21246,7 @@
 						<second>-1.38458695570385526e+00</second>
 					</item>
 				</goal_state>
-				<score>7.98748959530067082e-01</score>
+				<score>5.00338566646675309e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21309,34 +21309,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41843351581077148e+00</second>
+						<second>-1.42245244493373502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.78319563654310315e-01</second>
+						<second>2.96699995424302720e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34931182928850713e+00</second>
+						<second>1.35001499331085451e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.96093992525061034e-01</second>
+						<second>2.14873641123763504e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.77776892531010633e-01</second>
+						<second>-9.73661213467338138e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.20205536854555717e-01</second>
+						<second>-3.17516705638742402e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62083700425522848e+00</second>
+						<second>-1.62072046876065889e+00</second>
 					</item>
 				</goal_state>
-				<score>2.63531783019671462e+00</score>
+				<score>1.65207118984113027e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21399,34 +21399,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50543660616521846e+00</second>
+						<second>-4.17588586264686715e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.01428715381140266e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.45213180240910900e+00</second>
+						<second>6.06212190427747211e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26396198950061311e+00</second>
+						<second>5.24292296574514260e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.79962259085595444e-01</second>
+						<second>-2.11294631874168459e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.78345281350388640e-01</second>
+						<second>3.13199334167128773e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80311134697619613e+00</second>
+						<second>1.80315499052299422e+00</second>
 					</item>
 				</goal_state>
-				<score>2.45698249081103093e+00</score>
+				<score>6.56120657037482929e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -21669,34 +21669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.31279848142159627e+00</second>
+						<second>-1.30932617866798773e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.28427860333888932e+00</second>
+						<second>-1.27378257801040018e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>3.13529542881144319e-01</second>
+						<second>3.10486210760150538e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93148330795419887e+00</second>
+						<second>-1.92440721109101331e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26120040811812528e-01</second>
+						<second>-2.29100948928916304e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.00391452474418497e+00</second>
+						<second>1.00525340992487999e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56747055780516575e-01</second>
+						<second>-8.56743938941083472e-01</second>
 					</item>
 				</goal_state>
-				<score>1.01960474299321935e+00</score>
+				<score>6.38382711799790475e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21786,7 +21786,7 @@
 						<second>-1.20688686949219215e+00</second>
 					</item>
 				</goal_state>
-				<score>7.85048942750641521e-01</score>
+				<score>4.92361739727776720e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21876,7 +21876,7 @@
 						<second>-1.42467214061561132e+00</second>
 					</item>
 				</goal_state>
-				<score>1.00877654328172284e+00</score>
+				<score>6.31928250606852981e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -22209,34 +22209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36984688182599701e+00</second>
+						<second>-1.35879102514353689e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.09668359201378918e+00</second>
+						<second>-1.03301927387860326e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.31403171902181337e-01</second>
+						<second>5.21155571290488284e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.22960457700863923e+00</second>
+						<second>-2.17845913744888087e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.62503521049752275e-01</second>
+						<second>-7.74244795111429296e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.72145748988536140e-01</second>
+						<second>8.80165529854314621e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73019876767437786e-01</second>
+						<second>-4.72734429368809272e-01</second>
 					</item>
 				</goal_state>
-				<score>1.00019891493500324e+00</score>
+				<score>6.24289492100097709e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -22326,7 +22326,7 @@
 						<second>-9.36061044236672468e-01</second>
 					</item>
 				</goal_state>
-				<score>1.28056407120803861e+00</score>
+				<score>8.03735438214575604e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -22416,7 +22416,7 @@
 						<second>-1.22461195462655459e+00</second>
 					</item>
 				</goal_state>
-				<score>1.13704095935319516e+00</score>
+				<score>7.14138482677444397e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -22839,34 +22839,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.39762143704029951e+00</second>
+						<second>-1.22919003833926599e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.12909883564437530e-01</second>
+						<second>2.96699999299039918e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.77314135531905159e-01</second>
+						<second>-9.95958189848284992e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.28170979356046999e+00</second>
+						<second>-1.52571289918008057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.87273257558904493e-01</second>
+						<second>1.96961592789231954e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.56940971734648160e+00</second>
+						<second>5.03033323057581083e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.90410927425032783e-01</second>
+						<second>4.90687878237051622e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45529021425194038e+00</score>
+				<score>8.96778424625278153e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -25331,31 +25331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>1.85751719504309243e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>-1.11890668014312222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>-1.56826277046069529e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>5.89502137757869860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>-2.60144910925707329e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>2.03436934144451076e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>-1.20888262810994163e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25363,34 +25363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38907410341079363e+00</second>
+						<second>1.52189635862126349e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.34751326569653374e-01</second>
+						<second>-1.07745970039060657e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47511496728800617e+00</second>
+						<second>-1.36912713306532230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.14697583568047801e+00</second>
+						<second>5.08167938023236343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.92445581713455982e-01</second>
+						<second>-2.26273290794743298e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.07681608067439982e+00</second>
+						<second>1.94205639971016164e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.09065740317828586e-01</second>
+						<second>-5.09124781806770788e-01</second>
 					</item>
 				</goal_state>
-				<score>1.75624935457027176e+00</score>
+				<score>1.20280616160555423e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25421,31 +25421,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976185378250541e+00</second>
+						<second>1.85751719504309243e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30316440294132097e+00</second>
+						<second>-1.11890668014312222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46111322189258197e+00</second>
+						<second>-1.56826277046069529e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.77135264777069157e-01</second>
+						<second>5.89502137757869860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.99930916189362362e-01</second>
+						<second>-2.60144910925707329e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.23167852576770809e+00</second>
+						<second>2.03436934144451076e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20867229288439715e+00</second>
+						<second>-1.20888262810994163e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25453,34 +25453,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66546977487627457e+00</second>
+						<second>1.62693865966356754e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30975980260474123e+00</second>
+						<second>-1.11394105130887366e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.45006209544128772e+00</second>
+						<second>-1.52013344363592173e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.57511725738580866e-01</second>
+						<second>5.56243574805227903e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.09548167837764088e-01</second>
+						<second>-2.40562790539430127e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.32301590495953492e+00</second>
+						<second>1.89717060392078207e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.88192573850707734e-01</second>
+						<second>-7.88155701525559138e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57900683019595256e+00</score>
+				<score>1.73941814284345048e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25511,31 +25511,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>-1.89934967083435358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-1.28922831338487320e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.62864658860894163e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>5.37705728383437442e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>4.27369121000988228e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-1.26309285177837727e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>1.32184816522921489e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25543,34 +25543,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70180119824979714e+00</second>
+						<second>-1.64824162395894369e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61208933347308236e+00</second>
+						<second>-1.28435015350388437e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46789399067866877e+00</second>
+						<second>1.60241270551817983e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.78573417810699631e-01</second>
+						<second>5.11533692956191888e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.38729469789955151e-01</second>
+						<second>6.55380854213489905e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.55641411698714749e+00</second>
+						<second>-1.40670776941690279e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58804363550193961e-01</second>
+						<second>8.58792042577324000e-01</second>
 					</item>
 				</goal_state>
-				<score>2.86537122691224111e+00</score>
+				<score>1.84593886641881477e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25601,31 +25601,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>1.90002293987170301e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>6.46003484800312444e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.29993060972074304e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>-4.69075453698148237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>6.65829107847038304e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-2.75008506656012175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>-1.02752767733299200e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25633,34 +25633,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73460503512780018e+00</second>
+						<second>1.70896087777688277e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28448050793543178e+00</second>
+						<second>6.03258611542462297e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47679066904701273e+00</second>
+						<second>1.43003070551701827e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.90867035649140537e-01</second>
+						<second>-4.46893823630272524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.74561620978228560e-01</second>
+						<second>8.27159422189506000e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.52996780009756805e-01</second>
+						<second>-2.56669196792404053e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.00617945325530367e-01</second>
+						<second>-6.00568522518465042e-01</second>
 					</item>
 				</goal_state>
-				<score>2.05977624675478443e+00</score>
+				<score>1.45150276762908231e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25691,31 +25691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>1.86299856929415530e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>-1.04590777759692299e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>-1.62636131711153542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>4.32176864356211998e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>-2.84743403392235050e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>2.19123746123858032e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>-1.67185235868050230e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25723,34 +25723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83360884213563291e+00</second>
+						<second>1.66593639504934088e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92958175926217423e+00</second>
+						<second>2.36730032348562425e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56922605030601625e+00</second>
+						<second>1.73340012339663230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54053993085076923e+00</second>
+						<second>1.04201880752725873e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50630410683652505e+00</second>
+						<second>7.42442159206750829e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.17175106818797792e+00</second>
+						<second>-2.01375906323112019e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42909495308566714e-01</second>
+						<second>-9.42904364820772112e-01</second>
 					</item>
 				</goal_state>
-				<score>2.73833264850141678e+00</score>
+				<score>1.94014222011031495e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25781,31 +25781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>1.86299856929415530e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-1.04590777759692299e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>-1.62636131711153542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>4.32176864356211998e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>-2.84743403392235050e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>2.19123746123858032e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>-1.67185235868050230e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25813,34 +25813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88566865222674851e+00</second>
+						<second>1.84567120882302316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.37577388121325095e+00</second>
+						<second>-1.25827623495047747e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.61480352082282730e+00</second>
+						<second>1.67410152553747316e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.32038987290790799e-01</second>
+						<second>-2.48150467716417511e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.31608048721753712e-01</second>
+						<second>5.47274687915783931e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.48037229724794317e-01</second>
+						<second>-2.13226726552269907e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06263268088547380e+00</second>
+						<second>1.06227694707920128e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97853579320359563e+00</score>
+				<score>2.03187611906280152e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25871,31 +25871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25903,34 +25903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>1.90002293987170301e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.40538538113626199e+00</second>
+						<second>6.46003484800312444e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.32628472886373538e+00</second>
+						<second>1.29993060972074304e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.75872425370206986e-01</second>
+						<second>-4.69075453698148237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32702448192824285e-01</second>
+						<second>6.65829107847038304e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.38228833737893286e-01</second>
+						<second>-2.75008506656012175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.02767833755982729e+00</second>
+						<second>-1.02752767733299200e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88357235575551707e+00</score>
+				<score>2.02470908347816003e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25961,31 +25961,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>1.91287293144251569e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>-2.95318221313568818e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.16297445201094218e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>2.54054882039876428e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>5.74818783803140998e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>-3.04409974385455850e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>1.64539535452074714e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25993,34 +25993,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73845365113803330e+00</second>
+						<second>1.88299163115954160e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90633937476718662e+00</second>
+						<second>-2.85275123050216761e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51213740750317660e+00</second>
+						<second>1.51692084888680512e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.03803551979915598e+00</second>
+						<second>2.57552894465448823e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.20958329212663074e+00</second>
+						<second>7.65104367420638254e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20861037790856335e-01</second>
+						<second>-2.78612470565966230e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.89434430445925783e-01</second>
+						<second>6.88971620906042248e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34282407268101167e+00</score>
+				<score>1.59277723186383641e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26051,31 +26051,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90738882400318444e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.33099285631573339e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62320284700062900e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.01906302293365736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.82548700180940589e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23671183688667985e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032586629972160e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26083,34 +26083,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76577378666234819e+00</second>
+						<second>-1.91978124277972695e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.99664117009518804e+00</second>
+						<second>-1.44028917404360768e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86796749162818920e+00</second>
+						<second>1.65639179561152927e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34730382106805679e+00</second>
+						<second>4.85731972267398504e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78163388304197534e+00</second>
+						<second>2.98584303745697499e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96675406574584533e+00</second>
+						<second>-1.38850936076816778e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46463993745789089e+00</second>
+						<second>1.46458924817000047e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15283201945132197e+00</score>
+				<score>2.02992813256472920e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26141,31 +26141,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26173,34 +26173,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73643636432677173e+00</second>
+						<second>1.83504605920255459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>-2.75682755701901439e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01878274703353910e+00</second>
+						<second>1.05059154458068860e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97534025482065623e-01</second>
+						<second>2.39084647300655684e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750756914439298e-01</second>
+						<second>6.59106808254213306e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12586922386320393e-02</second>
+						<second>-2.99717002900289753e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48868350544926020e+00</second>
+						<second>1.48872238273390245e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13200839639488127e+00</score>
+				<score>1.98867969337978123e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26231,31 +26231,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.83693070389912227e+00</second>
+						<second>-1.76225808221312374e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82927561456175836e+00</second>
+						<second>2.70968374611173735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46863845655415437e+00</second>
+						<second>1.49551508442191183e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.13583353493909334e+00</second>
+						<second>-1.11997372408082874e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31602270875400817e+00</second>
+						<second>8.94199559489954554e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.50312110900653939e-01</second>
+						<second>-1.92762577805533269e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26240530216323976e+00</second>
+						<second>1.26216419835998694e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26263,34 +26263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77730466495425832e+00</second>
+						<second>-1.70528585540035094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96693061005466019e+00</second>
+						<second>2.83375026030477706e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35301256598507447e+00</second>
+						<second>1.36880938887057968e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02883438955599127e+00</second>
+						<second>-1.23020358553835329e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23154570961572851e+00</second>
+						<second>9.76405017172991108e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.56557792585911321e-02</second>
+						<second>-9.67189723867948464e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11737135502758700e+00</second>
+						<second>1.11776257378491595e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95305310401394205e+00</score>
+				<score>2.07136926222882850e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26321,31 +26321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77755263558543453e+00</second>
+						<second>1.63236938080690508e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699989279006138e+00</second>
+						<second>-4.36607437573743540e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35310061129518022e+00</second>
+						<second>1.39292928836775110e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02930959564206281e+00</second>
+						<second>-1.34234039958010198e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23167488840808570e+00</second>
+						<second>1.03840677348638954e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.57716466066921579e-02</second>
+						<second>3.02353037104727118e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11743113545222017e+00</second>
+						<second>-1.11738197629355129e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26353,34 +26353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>1.78416449286716561e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>-5.35711269747248697e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.65975016101922490e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>-1.34397243516516829e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>9.13048660983535876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>3.11628787587093958e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>-7.95014837995839496e-01</second>
 					</item>
 				</goal_state>
-				<score>2.66341740938212457e+00</score>
+				<score>1.69282640368036585e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26411,31 +26411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>1.71532157304109645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-2.19444806960472361e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>-8.87096666763956931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>2.56496469136614058e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>-2.50994284845416482e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>-9.44423488227924129e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>2.13513061619105882e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26443,34 +26443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76432032113259485e+00</second>
+						<second>1.59390261202281480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.87785049076220245e+00</second>
+						<second>-1.04272814171462280e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.23704501601275485e-01</second>
+						<second>-9.06368755617783961e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54266727284059657e-01</second>
+						<second>2.31171557425302909e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.69774067705066001e-01</second>
+						<second>-2.30084642174203990e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.73707676792904664e+00</second>
+						<second>2.18481314485024447e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969489732625302e+00</second>
+						<second>1.83965353950061883e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55087012000224123e+00</score>
+				<score>1.60502128467923860e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26501,31 +26501,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26533,34 +26533,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.90671443966079757e+00</second>
+						<second>1.84020580356262520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.34998784088533716e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16128734813458734e+00</second>
+						<second>1.15173571439528866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.12770414495120375e-01</second>
+						<second>-7.23444680925793393e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.84660858584042598e-01</second>
+						<second>6.84586667469191501e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.82601379903193706e-02</second>
+						<second>3.14149998474369552e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64534015551516544e+00</second>
+						<second>-1.64532103737375168e+00</second>
 					</item>
 				</goal_state>
-				<score>2.89507518002620889e+00</score>
+				<score>1.90417287988765893e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26591,31 +26591,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.91287293144251569e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-2.95318221313568818e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.16297445201094218e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>2.54054882039876428e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>5.74818783803140998e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-3.04409974385455850e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.64539535452074714e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26623,34 +26623,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>-1.76225808221312374e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>2.70968374611173735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>1.49551508442191183e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>-1.11997372408082874e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>8.94199559489954554e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>-1.92762577805533269e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>1.26216419835998694e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24930532361811997e+00</score>
+				<score>2.07301462454764773e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26681,31 +26681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>1.86132747163009293e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>-2.37678445956883727e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>-1.08431067162434958e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>2.56137132538180223e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>-2.57150166606030384e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>-1.90211637578952264e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>2.02127514603670999e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26713,34 +26713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64571191192112232e+00</second>
+						<second>1.65688292895327449e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999993822594e+00</second>
+						<second>-1.50031487114000578e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84622695735727160e-01</second>
+						<second>-8.82007247245441106e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42861785976288269e+00</second>
+						<second>2.43794562219982769e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39151429858587949e+00</second>
+						<second>-2.41081277599054333e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.10782441521467589e+00</second>
+						<second>4.70838005037550675e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02190006863153560e+00</second>
+						<second>2.02198753023086830e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11139341966240446e+00</score>
+				<score>1.32556329353547608e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26771,31 +26771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.73059441372875944e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-1.63560327302609543e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.64948195692009603e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>4.00432284766414237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>2.59200916283703897e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>1.60360807059138777e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>-2.23624999183108608e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26803,34 +26803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78985632045988452e+00</second>
+						<second>-1.89327592413163348e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999109129164e+00</second>
+						<second>3.59441697037389124e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09594750456878920e+00</second>
+						<second>1.08566768038474826e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42565080387072296e+00</second>
+						<second>2.56383405843571888e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44198019251436227e+00</second>
+						<second>5.34296442579378361e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.89037672528895112e-01</second>
+						<second>-4.66906697208263194e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87555194285101900e+00</second>
+						<second>-1.87547627807663675e+00</second>
 					</item>
 				</goal_state>
-				<score>2.49956404149079070e+00</score>
+				<score>1.59229683019899204e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26861,31 +26861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.60993243574549361e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.46990424669438391e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.40937057711447977e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.59515267602153665e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-5.48829906523652711e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.75230748926813562e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26893,34 +26893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.81419271220823308e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.79523202713398167e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.40364423475534617e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>2.23878387106581211e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-2.38685501439117820e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-3.14957407979780446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>-1.55307046901980694e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.96795704467592952e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26951,31 +26951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>-1.55797369663684360e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>2.96699999963059735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>9.12130088755938706e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>-8.59631023003549544e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>8.92495716358120417e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>-2.95503591783539399e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>1.83959999216321290e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26983,34 +26983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.67163682240829337e+00</second>
+						<second>1.71532157304109645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.20775336534649014e-01</second>
+						<second>-2.19444806960472361e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.04870068879646494e-01</second>
+						<second>-8.87096666763956931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.14186447570347460e-01</second>
+						<second>2.56496469136614058e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.13941311284461699e-01</second>
+						<second>-2.50994284845416482e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.59286796880928005e-01</second>
+						<second>-9.44423488227924129e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13516254928943283e+00</second>
+						<second>2.13513061619105882e+00</second>
 					</item>
 				</goal_state>
-				<score>1.80122071559398589e+00</score>
+				<score>1.13417603292817595e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27041,31 +27041,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>1.83568927460245579e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-3.77668847137699548e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>-9.34913554794419843e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>2.82868702620651780e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>-2.70664354894977421e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>-3.08025387285031982e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>2.23354922750770601e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27073,34 +27073,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82351156045076945e+00</second>
+						<second>1.86681707505848560e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.13157575006690225e-01</second>
+						<second>-2.26844351632884245e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.10013043441297564e+00</second>
+						<second>-1.08260236234389340e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.27130085717839902e-01</second>
+						<second>2.56819844274151876e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32418792253928608e-01</second>
+						<second>-2.58052474577867264e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47226508039611881e-01</second>
+						<second>-1.81536366532387722e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02113601224369965e+00</second>
+						<second>2.02113489342873720e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11572347952623829e+00</score>
+				<score>1.34983854387919155e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27131,31 +27131,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.60993243574549361e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.46990424669438391e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>2.40937057711447977e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-2.59515267602153665e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-5.48829906523652711e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>-1.75230748926813562e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27163,34 +27163,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>-1.84323029595392818e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>2.71134354474167782e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>-1.41154774062812605e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>2.33803850175277361e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>-2.47547203734842114e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>-4.37681836857678475e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>-1.70663870827129704e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85393480187066562e+00</score>
+				<score>1.80423658110260621e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27221,31 +27221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.28412089218715608e+00</second>
+						<second>1.71532157304109645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.20243170065254024e+00</second>
+						<second>-2.19444806960472361e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.20538832501352755e+00</second>
+						<second>-8.87096666763956931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33912915583231618e+00</second>
+						<second>2.56496469136614058e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.96393597548850907e+00</second>
+						<second>-2.50994284845416482e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53920838898038648e+00</second>
+						<second>-9.44423488227924129e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13504078639388295e+00</second>
+						<second>2.13513061619105882e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27253,34 +27253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-3.83591262621573115e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>-1.11929637839989882e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>2.69621891875625419e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-2.67714689200277611e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>-3.72707836979269291e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>2.09712653119559400e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82794735082438553e+00</score>
+				<score>1.21400283368234690e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27311,31 +27311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27343,34 +27343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976366967758727e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60944675272011439e+00</second>
+						<second>2.60993243574549361e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47016038483363554e+00</second>
+						<second>-1.46990424669438391e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40928528208225590e+00</second>
+						<second>2.40937057711447977e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59495987891154334e+00</second>
+						<second>-2.59515267602153665e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.49378241225392028e-01</second>
+						<second>-5.48829906523652711e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75229127949802055e+00</second>
+						<second>-1.75230748926813562e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70078461231943301e+00</score>
+				<score>1.73177595833408443e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27401,31 +27401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>1.83568927460245579e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-3.77668847137699548e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>-9.34913554794419843e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>2.82868702620651780e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-2.70664354894977421e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>-3.08025387285031982e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>2.23354922750770601e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27433,34 +27433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>1.91873069933077312e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-7.14344142421292294e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.27527039457789537e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>2.69460163416413812e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.67059522158401208e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>-7.34528517661742653e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.09819397322135437e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83991615996556024e+00</score>
+				<score>1.20271489131401899e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27491,31 +27491,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>-1.91442672980341522e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>3.13855007847417933e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>1.37334154347763726e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>-2.44242056033269606e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>-5.80278858040322532e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>3.52302746154257773e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>-1.70886242568937097e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27523,34 +27523,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91979999999999995e+00</second>
+						<second>-1.91976441160022393e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35506134573384474e-01</second>
+						<second>5.35650806662432810e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47321701443612763e+00</second>
+						<second>1.47331051692181902e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33548484254081479e-01</second>
+						<second>-2.40791820863382222e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.45261440489975158e-01</second>
+						<second>-5.45346397836879548e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58899827189118925e+00</second>
+						<second>5.52775059593614393e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75067389718719335e+00</second>
+						<second>-1.75063720526079436e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68134014893157513e+00</score>
+				<score>1.73310153296642400e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27581,31 +27581,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27613,34 +27613,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>1.89980499453265583e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.11931701554997209e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.38146202175927768e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>2.83032007168870203e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-2.73945251123265932e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>-1.14519669493554277e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>2.14354104910291809e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79709988676116561e+00</score>
+				<score>1.11522445724317062e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27671,31 +27671,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91936760030488562e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.07006899300629543e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-1.32987684736916645e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>2.87841194190391425e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-2.76689122785017361e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-1.07642542074668524e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.14336674960685425e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27703,34 +27703,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83906436319784583e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72982808796894572e-01</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09009218730911694e+00</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06907580079819153e-01</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05064238863279424e-01</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.13657257703061959e-01</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01890526354003752e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</goal_state>
-				<score>2.12032625353634829e+00</score>
+				<score>1.33130169426273509e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27761,31 +27761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85912022245366959e+00</second>
+						<second>-1.76340300932831817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.08283851344100450e-02</second>
+						<second>2.23918748686015023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79410515019637296e-01</second>
+						<second>1.10598400589517243e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.35530877370318004e-01</second>
+						<second>-2.39358882999928735e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.84419919361993445e+00</second>
+						<second>-7.38946357585954949e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.12394418269568197e+00</second>
+						<second>2.19495764180682479e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19437947792203270e+00</second>
+						<second>-1.87150095554267715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27793,34 +27793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59040032317572422e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.25748139098524758e-01</second>
+						<second>3.04162448174498778e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55252373234415697e+00</second>
+						<second>1.37069987918811065e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.05859574777155374e+00</second>
+						<second>-2.45147660413979729e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24939292366541110e+00</second>
+						<second>-5.72791924639454719e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.22358924053912133e-01</second>
+						<second>3.44771725739662083e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70879017276738199e+00</second>
+						<second>-1.70915297844782654e+00</second>
 					</item>
 				</goal_state>
-				<score>2.73475493310752960e+00</score>
+				<score>1.81527350256331321e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27851,31 +27851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>1.78091255903302059e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-2.67729811455601985e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.02531633882814299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>-2.31014528640487082e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>2.41453102013269882e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>3.04997388314012507e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>1.49969943349716051e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27883,34 +27883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78203500138374138e+00</second>
+						<second>-1.91966369462155062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.27978460146796980e-01</second>
+						<second>-1.28713818397393509e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.88101320552870166e-01</second>
+						<second>1.53795747481161782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92690938843703385e-01</second>
+						<second>2.76427963760903150e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62333651587539540e+00</second>
+						<second>2.39858418603691503e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93162405027364104e+00</second>
+						<second>1.76540545814243122e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.01047153560230329e+00</second>
+						<second>-2.01023623802223117e+00</second>
 					</item>
 				</goal_state>
-				<score>2.14369794781655632e+00</score>
+				<score>1.34755252616136800e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27941,31 +27941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>-1.91309496120993972e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>1.82475303797773380e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>1.44717582448465043e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.26849798166342920e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>-7.44727370361469410e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>9.96199261834082583e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>-1.27424667332179875e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27973,34 +27973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61361950955022571e+00</second>
+						<second>-1.77067913034333047e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.67969749140427815e+00</second>
+						<second>2.11149882508357256e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16529629000683621e+00</second>
+						<second>1.10407270792399248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.25588823197027821e+00</second>
+						<second>-2.40132954987103231e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.21535386856614958e-01</second>
+						<second>-7.28995536429001945e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.78085331633099564e+00</second>
+						<second>2.11440895217382768e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87147638534520722e+00</second>
+						<second>-1.87143725143120543e+00</second>
 					</item>
 				</goal_state>
-				<score>2.46953421708869625e+00</score>
+				<score>1.59567188143075217e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28031,31 +28031,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>-1.91442672980341522e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>3.13855007847417933e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>1.37334154347763726e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.44242056033269606e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>-5.80278858040322532e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.52302746154257773e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>-1.70886242568937097e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28063,34 +28063,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72484293883013562e+00</second>
+						<second>-1.88959075720037784e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.67563801967791148e+00</second>
+						<second>2.24518838583943808e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43607506677960295e+00</second>
+						<second>1.37522973443973906e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.13392111505164994e+00</second>
+						<second>-2.34954779409865555e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.41673556929095401e-01</second>
+						<second>-6.70208060915579829e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.76558597281324836e+00</second>
+						<second>2.41887714220259564e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.55605715978746817e+00</second>
+						<second>-1.55604765028950465e+00</second>
 					</item>
 				</goal_state>
-				<score>3.04469197753052256e+00</score>
+				<score>1.97503356862193363e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28121,31 +28121,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>1.91959300449863335e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-1.28719460706379230e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.53802395200535602e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>2.76420216320165268e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-2.90169224967037476e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>-1.37625898048339113e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>2.01025368267273041e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28153,34 +28153,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73254856244761690e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.90109703440959010e-01</second>
+						<second>-1.38760209889569519e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.12676329589922397e-01</second>
+						<second>-1.59666257864280992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.92545466147565403e-01</second>
+						<second>2.75431970198732001e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51905021486234304e+00</second>
+						<second>-3.09013511167980326e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77883103260827058e+00</second>
+						<second>-1.48376342534719030e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84180491085427445e+00</second>
+						<second>1.84170789554129244e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55327658368746935e+00</score>
+				<score>1.61728453203840022e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28211,31 +28211,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.90564296921643028e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>2.65761537758177790e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.62621197979295062e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.07191700270467338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.32685706712400897e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>3.11803177323347835e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>7.72799006467270511e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28243,34 +28243,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.83251855467987834e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>-2.89490035801685947e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.14155002498915992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.41663721186720037e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>2.45343939888830898e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.14014257755232506e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>1.65800016281128926e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88344875480654794e+00</score>
+				<score>1.88962986080427192e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28301,31 +28301,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>-1.76340300932831817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.23918748686015023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>1.10598400589517243e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.39358882999928735e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>-7.38946357585954949e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>2.19495764180682479e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>-1.87150095554267715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28333,34 +28333,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77079723307309278e+00</second>
+						<second>-1.91309496120993972e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.72152087045429569e+00</second>
+						<second>1.82475303797773380e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.49050615547571086e+00</second>
+						<second>1.44717582448465043e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.03707803166231427e+00</second>
+						<second>-2.26849798166342920e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.84700133661556642e-01</second>
+						<second>-7.44727370361469410e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.94490743873896488e+00</second>
+						<second>9.96199261834082583e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27428990918365015e+00</second>
+						<second>-1.27424667332179875e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24004368493468231e+00</score>
+				<score>2.08346736319808684e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28391,31 +28391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28423,34 +28423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>-1.90034414879669367e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>1.40353762296725626e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>1.68249729488399002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>-5.30086379051169732e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>-3.12133549267540833e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>1.36122960054940778e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>1.44919930561768728e+00</second>
 					</item>
 				</goal_state>
-				<score>3.20796298364267729e+00</score>
+				<score>2.03301147042730834e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28481,31 +28481,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60176987721037456e+00</second>
+						<second>1.76333446444974840e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.45731572692133055e-02</second>
+						<second>2.14916708297422515e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36846937573378558e+00</second>
+						<second>-1.53292026900899248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.54855432878719546e-01</second>
+						<second>-2.05846453461092338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18143121899762260e+00</second>
+						<second>2.22200722605283785e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.40819129955978550e-01</second>
+						<second>2.90645385464913764e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33444492832379469e-01</second>
+						<second>6.42325850168180668e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28513,34 +28513,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69842527437781610e+00</second>
+						<second>1.66951464868607879e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.92130704492299453e-02</second>
+						<second>-4.26537018441166399e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.00863692662598292e+00</second>
+						<second>-1.00647869140077262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.42238626169744853e-01</second>
+						<second>-2.16430007432672245e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.30919294546896570e+00</second>
+						<second>2.27354636161148704e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35519750969554569e-02</second>
+						<second>3.13844220845669986e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49960548086532408e+00</second>
+						<second>1.49964826037106236e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203462616953177e+00</score>
+				<score>1.99318686212401036e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28571,31 +28571,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>-1.76340300932831817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.23918748686015023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>1.10598400589517243e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.39358882999928735e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>-7.38946357585954949e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>2.19495764180682479e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>-1.87150095554267715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28603,34 +28603,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70532887478218864e+00</second>
+						<second>-1.81561672085701398e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.85043042302404181e+00</second>
+						<second>8.37373723048996377e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.35530166467592417e+00</second>
+						<second>1.33572140648081672e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93134620162400972e+00</second>
+						<second>-2.11418714753902082e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.71353674829156133e-01</second>
+						<second>-8.65479892632846082e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04517589367200125e+00</second>
+						<second>4.19913298071143484e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.13907202439606658e+00</second>
+						<second>-1.13902712801705697e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97595483397852423e+00</score>
+				<score>2.08197229780373888e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28661,31 +28661,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76333446444974840e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.14916708297422515e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.53292026900899248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.05846453461092338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.22200722605283785e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.90645385464913764e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>6.42325850168180668e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28693,34 +28693,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90606274159480016e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.64309184688986787e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62590454837323284e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07328628834398510e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32729595104946263e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11787249449471693e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.73090110138695663e-01</second>
 					</item>
 				</goal_state>
-				<score>2.59969201292127350e+00</score>
+				<score>1.65586451354595821e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28751,31 +28751,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78773248346576441e+00</second>
+						<second>-1.68304021847771823e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.77837666166757424e+00</second>
+						<second>7.58706155662025594e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79446502359811144e+00</second>
+						<second>1.74387237442897547e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.78973881227557063e-01</second>
+						<second>-9.44176909666115671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66580929203518568e+00</second>
+						<second>-6.60358574178019797e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04684989523332916e+00</second>
+						<second>9.16747584239542945e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04573451725265532e+00</second>
+						<second>1.22483474277359083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28783,34 +28783,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.79362345948912272e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>1.13204876654422759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.59772644502839500e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-6.72800604964027937e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-6.53831505002115065e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>-1.01130830892028234e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>9.35106417855317895e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74544013012387067e+00</score>
+				<score>1.93508660268908145e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28841,31 +28841,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.68304021847771823e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>7.58706155662025594e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.74387237442897547e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-9.44176909666115671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-6.60358574178019797e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>9.16747584239542945e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.22483474277359083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28873,34 +28873,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91975139782178017e+00</second>
+						<second>-1.89968041747619520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61530546905488248e+00</second>
+						<second>1.44551685551853892e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53904101949741046e+00</second>
+						<second>1.58232487314126624e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.59151008199688482e-01</second>
+						<second>-4.51801130758147873e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62911373120048264e+00</second>
+						<second>-5.16058899615306821e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.75310105667776561e-01</second>
+						<second>-9.24695621120972033e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08011791867018081e+00</second>
+						<second>1.08036787337582463e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07006280327215197e+00</score>
+				<score>2.05403289728522370e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28931,31 +28931,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.38760209889569519e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.59666257864280992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>2.75431970198732001e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-3.09013511167980326e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>-1.48376342534719030e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.84170789554129244e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28963,34 +28963,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91754913755242162e+00</second>
+						<second>-1.91979656631420958e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.36744180198839604e+00</second>
+						<second>2.33740873620461409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58381731597348807e+00</second>
+						<second>-1.33648955839465211e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.27813500556508708e-01</second>
+						<second>-2.82756500236209618e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66623175791702449e+00</second>
+						<second>2.53565343994524417e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.28905584564159859e-01</second>
+						<second>-4.81923715152446142e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04547202754940094e+00</second>
+						<second>-1.04553215887862061e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95464529793425212e+00</score>
+				<score>2.04298490883778078e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29021,31 +29021,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90564296921643028e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.65761537758177790e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62621197979295062e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07191700270467338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32685706712400897e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11803177323347835e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72799006467270511e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29053,34 +29053,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.76333446444974840e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>2.14916708297422515e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.53292026900899248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.05846453461092338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.22200722605283785e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>2.90645385464913764e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>6.42325850168180668e-01</second>
 					</item>
 				</goal_state>
-				<score>2.16823251488438951e+00</score>
+				<score>1.50677645687827377e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29111,31 +29111,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56462825203793021e+00</second>
+						<second>-1.68304021847771823e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.15610684099707095e+00</second>
+						<second>7.58706155662025594e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71305861025194162e+00</second>
+						<second>1.74387237442897547e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32983370913493371e+00</second>
+						<second>-9.44176909666115671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42867529052722730e+00</second>
+						<second>-6.60358574178019797e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83677130336604399e+00</second>
+						<second>9.16747584239542945e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43433687284591116e-01</second>
+						<second>1.22483474277359083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29143,34 +29143,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.48923496664104738e+00</second>
+						<second>-1.45438349221361807e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.25065311632395559e+00</second>
+						<second>7.20634507692806681e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41434574949438252e+00</second>
+						<second>1.44496313205961258e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44687790582781695e+00</second>
+						<second>-8.63944831164350391e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24143394036810983e+00</second>
+						<second>-9.29963915106310601e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.98500457715291523e+00</second>
+						<second>1.12130274387269901e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.19425780294794914e-01</second>
+						<second>5.19214887593787200e-01</second>
 					</item>
 				</goal_state>
-				<score>1.80804794091836873e+00</score>
+				<score>1.22584304040043252e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29201,31 +29201,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29233,34 +29233,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63223108688898666e+00</second>
+						<second>-1.66315608277712257e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01777752284855882e+00</second>
+						<second>1.27701745939159794e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51494615570768176e+00</second>
+						<second>1.46012012854102724e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.45570727533466138e-01</second>
+						<second>-3.90009746294556203e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40847590031933034e+00</second>
+						<second>-7.11650882555942998e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.24525430535861514e+00</second>
+						<second>1.30639242395839217e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90981838959245120e-01</second>
+						<second>7.91152006168943878e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57147490887186558e+00</score>
+				<score>1.74066524707295944e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29291,31 +29291,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29323,34 +29323,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.62646346208097903e+00</second>
+						<second>-1.66404816074078354e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.95370442611607364e+00</second>
+						<second>1.34225652925890171e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.64150544259169817e+00</second>
+						<second>1.58182247613041160e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.17344369057844400e-01</second>
+						<second>-4.63623044038795562e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46639989721338759e+00</second>
+						<second>-6.56345559987383087e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.37605961510617480e+00</second>
+						<second>1.43877437183136858e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43361859118155310e-01</second>
+						<second>8.43391684331719627e-01</second>
 					</item>
 				</goal_state>
-				<score>2.79220939138916702e+00</score>
+				<score>1.82947449983595245e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29381,31 +29381,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91979656631420958e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>2.33740873620461409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>-1.33648955839465211e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-2.82756500236209618e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>2.53565343994524417e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>-4.81923715152446142e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>-1.04553215887862061e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29413,34 +29413,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74753649668544342e+00</second>
+						<second>-1.73322150657936613e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.04791145152498433e+00</second>
+						<second>2.38465643189445364e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51338568980158206e+00</second>
+						<second>-1.44654608972750176e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.49056752460664458e-03</second>
+						<second>-2.84850992083411159e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.41245183190154533e+00</second>
+						<second>2.35935589847991967e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-7.23523336408422812e-01</second>
+						<second>-6.23608664280539071e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33154400576498855e-01</second>
+						<second>-6.33026352029928963e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15353501873858999e+00</score>
+				<score>1.51431380137903415e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -31181,31 +31181,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>1.85751719504309243e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>-1.11890668014312222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>-1.56826277046069529e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>5.89502137757869860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>-2.60144910925707329e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>2.03436934144451076e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>-1.20888262810994163e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31213,34 +31213,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50527518949420713e+00</second>
+						<second>1.63553966022073083e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.57686113309499765e-01</second>
+						<second>-1.09615722909305657e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43028405084706534e+00</second>
+						<second>-1.33056685372011252e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.22856019152355644e+00</second>
+						<second>5.76270547759073826e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.99573877707567893e-01</second>
+						<second>-2.24517723171961459e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09764371279093997e+00</second>
+						<second>1.94111025180416119e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.70755720247307163e-01</second>
+						<second>-4.70604140286366934e-01</second>
 					</item>
 				</goal_state>
-				<score>1.65021444059937239e+00</score>
+				<score>1.12667169581942478e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31271,31 +31271,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>1.85751719504309243e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-1.11890668014312222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>-1.56826277046069529e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>5.89502137757869860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>-2.60144910925707329e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>2.03436934144451076e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>-1.20888262810994163e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31303,34 +31303,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61628137603042710e+00</second>
+						<second>1.75218076635286724e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45042140993734003e+00</second>
+						<second>-1.11563580637471427e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60351359758469392e+00</second>
+						<second>-1.47848143856506842e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10586465725776195e+00</second>
+						<second>6.04121116540399572e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.30188418143135687e+00</second>
+						<second>-2.40026549328616223e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.05482021228547440e+00</second>
+						<second>1.92769083918361672e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81726973125779878e-01</second>
+						<second>-7.81853112547940321e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46427520873712513e+00</score>
+				<score>1.73002024075635419e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -31451,31 +31451,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.57282433165854352e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>-2.58672025068967748e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>1.29209508825219910e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>8.23908109589281845e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>8.13187606870205859e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-2.24038324435754999e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>1.22309419926522955e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31483,34 +31483,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.39077572316472042e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>-3.92563083824212788e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>1.02499157594024637e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>9.66198463097224458e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>1.02723109791817535e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-6.58146988257781285e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>4.41091804065838977e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35611262663608856e+00</score>
+				<score>8.69871480380585843e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31541,31 +31541,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.57282433165854352e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>-2.58672025068967748e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>1.29209508825219910e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>8.23908109589281845e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>8.13187606870205859e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-2.24038324435754999e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.22309419926522955e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31573,34 +31573,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.54793393782259581e+00</second>
+						<second>-1.48803676280688690e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63173912551387357e+00</second>
+						<second>-3.68596624065424983e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.25674152769054825e+00</second>
+						<second>1.28491510369820894e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.33053804203208292e+00</second>
+						<second>9.63162531877324257e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26814503634882536e+00</second>
+						<second>9.36141745722588681e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53788891515888571e+00</second>
+						<second>-5.54799952376103245e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.56754616469535990e-01</second>
+						<second>8.56822605650382596e-01</second>
 					</item>
 				</goal_state>
-				<score>2.54792321953025480e+00</score>
+				<score>1.64842126274234113e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31631,31 +31631,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.57282433165854352e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>-2.58672025068967748e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>1.29209508825219910e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>8.23908109589281845e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>8.13187606870205859e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-2.24038324435754999e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.22309419926522955e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31663,34 +31663,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.59467879450421957e+00</second>
+						<second>-1.51651049210456379e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60836799020910970e+00</second>
+						<second>-3.86196720424772710e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45915637718895019e+00</second>
+						<second>1.49612575297634121e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.27875242441330483e+00</second>
+						<second>1.00760006570779770e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.33501734742509770e+00</second>
+						<second>8.81350440856723094e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.51028362539048766e+00</second>
+						<second>-5.73705195867846518e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08377819807085096e+00</second>
+						<second>1.08391385129589524e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03003103977268218e+00</score>
+				<score>1.95747473897727842e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31721,31 +31721,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.55539227767475885e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-2.85148083581384437e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.57282428920260786e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>8.80080012165241010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>7.99631797348561379e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-2.95885584774935428e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>1.43981037091917718e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31753,34 +31753,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64093076962699436e+00</second>
+						<second>-1.50221762429405636e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50967640588486063e+00</second>
+						<second>-3.88599931589712011e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61759321053386107e+00</second>
+						<second>1.68656221630885916e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.24879611565712656e+00</second>
+						<second>1.10985324492346371e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40898542420573980e+00</second>
+						<second>8.56069981107334232e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.39496454987968033e+00</second>
+						<second>-6.57855064690747393e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617507519897037e+00</second>
+						<second>1.19631551695457850e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29176845995357858e+00</score>
+				<score>2.05790880357444056e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31811,31 +31811,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>1.86292966021315043e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-9.18848080104658682e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>-1.48641884745227104e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>3.41525804625184171e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>-2.78597355126024837e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>2.31969987381760223e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>-1.59159638358222022e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31843,34 +31843,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76082921697254369e+00</second>
+						<second>1.85341094387516581e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.23571126487810057e+00</second>
+						<second>-1.10855998961047231e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67717354907443927e+00</second>
+						<second>-1.57392794569410710e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.32955010971975174e+00</second>
+						<second>6.00824473248352309e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53334429239486258e+00</second>
+						<second>-2.59861652599435144e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15216559477337110e+00</second>
+						<second>2.04070938702475901e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20887095432987457e+00</second>
+						<second>-1.20883251491825905e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15568513832345676e+00</score>
+				<score>2.09076978069349079e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31901,31 +31901,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90738882400318444e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.33099285631573339e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62320284700062900e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.01906302293365736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.82548700180940589e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23671183688667985e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032586629972160e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31933,34 +31933,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80543311468609735e+00</second>
+						<second>-1.91969110787202335e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.05394518815942773e+00</second>
+						<second>-1.34142097120742276e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75272151513511765e+00</second>
+						<second>1.59422901049495724e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38947657219905762e+00</second>
+						<second>4.77775383411646271e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66399234032112409e+00</second>
+						<second>4.18539018600274482e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00827696029826619e+00</second>
+						<second>-1.30162076103787827e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32182745107173005e+00</second>
+						<second>1.32156135677925102e+00</second>
 					</item>
 				</goal_state>
-				<score>3.22755161028517534e+00</score>
+				<score>2.09626994340638306e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31991,31 +31991,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.59319091416639158e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>-2.12593003696807392e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>1.17840898274916128e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>7.65222901702612202e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>7.68733003311471874e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.22041346886694407e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.21426760438006576e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32023,34 +32023,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.51182890904833145e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>-3.17845455087575446e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>1.21067322481762241e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>8.60538519859153084e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>8.83879653205441707e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-3.77499978593620000e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>9.66603655478871615e-01</second>
 					</item>
 				</goal_state>
-				<score>2.67899184079623343e+00</score>
+				<score>1.68186795323394395e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32081,31 +32081,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.59319091416639158e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>-2.12593003696807392e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>1.17840898274916128e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>7.65222901702612202e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>7.68733003311471874e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-1.22041346886694407e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.21426760438006576e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32113,34 +32113,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.56431988817515832e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>-2.94329046539266559e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>1.36175570326899020e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>8.45485962618055642e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>8.26002770010348719e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-2.96532046725554443e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>1.22590003481870324e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06098279374594773e+00</score>
+				<score>1.91388424751862074e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32171,31 +32171,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.63291490022524033e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-2.08280198894241403e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.33794354323748999e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>7.67180767024753019e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>7.36519690118058290e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-9.31004042838342316e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.42475477342112589e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32203,34 +32203,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66324183031696138e+00</second>
+						<second>-1.56511937596810280e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.68999615578065532e+00</second>
+						<second>-3.00457558985574524e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52660958446832073e+00</second>
+						<second>1.56989033405116007e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.41595980571103564e+00</second>
+						<second>8.66157565166873922e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46232407944029097e+00</second>
+						<second>7.88186368339979126e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74134721652886393e+00</second>
+						<second>-3.04169178590340594e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44021273733013278e+00</second>
+						<second>1.44052589785608443e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17007047239096318e+00</score>
+				<score>1.97607189240507047e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32261,31 +32261,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68304180521979796e+00</second>
+						<second>1.85751719504309243e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.53365607891304689e+00</second>
+						<second>-1.11890668014312222e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91963070841924233e+00</second>
+						<second>-1.56826277046069529e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47098096580177762e+00</second>
+						<second>5.89502137757869860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.76847589017741891e+00</second>
+						<second>-2.60144910925707329e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.64281535957950764e+00</second>
+						<second>2.03436934144451076e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91448193145372647e+00</second>
+						<second>-1.20888262810994163e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32293,34 +32293,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>1.86292966021315043e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-9.18848080104658682e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>-1.48641884745227104e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>3.41525804625184171e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>-2.78597355126024837e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>2.31969987381760223e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>-1.59159638358222022e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07327955843602130e+00</score>
+				<score>1.91203209315239819e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32351,31 +32351,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>1.82766148086444957e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-1.25318572549013263e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>-1.79481201672597579e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>6.89931408346898256e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>-2.81117981574468523e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>1.89756621608731790e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>-1.46466944605691363e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32383,34 +32383,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76343536150351610e+00</second>
+						<second>1.86299856929415530e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.28917221203157073e+00</second>
+						<second>-1.04590777759692299e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76356426267541155e+00</second>
+						<second>-1.62636131711153542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51694194520703185e+00</second>
+						<second>4.32176864356211998e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.74860638873879193e+00</second>
+						<second>-2.84743403392235050e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.36622373415104859e+00</second>
+						<second>2.19123746123858032e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67186848616890305e+00</second>
+						<second>-1.67185235868050230e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88103207717149568e+00</score>
+				<score>1.85185678354247457e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32441,31 +32441,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90738882400318444e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.33099285631573339e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62320284700062900e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.01906302293365736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.82548700180940589e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23671183688667985e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032586629972160e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32473,34 +32473,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91979902229316024e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.35105958842485419e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.61825124864871750e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>3.90753593752554751e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>2.00339285920436067e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.26209620188961713e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.67056688086192162e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79943380847459355e+00</score>
+				<score>1.85418394551356447e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32531,31 +32531,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>-1.87703134538144933e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.29351154736963081e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>1.64843743495597073e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>2.54282813963229049e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>-2.36397110764513474e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>-1.21152729464887399e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>2.14037246545076565e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32563,34 +32563,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68164349903212140e+00</second>
+						<second>-1.91211192400933938e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79808063012355879e+00</second>
+						<second>-1.49334765229265498e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49061836099290979e-01</second>
+						<second>1.66452462436383430e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.00001141701076612e-01</second>
+						<second>4.33635830896701491e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50194916847385063e-01</second>
+						<second>1.22596649889543954e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53481305049739625e+00</second>
+						<second>-1.40146795220104936e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70871991830956271e+00</second>
+						<second>1.70859696995764021e+00</second>
 					</item>
 				</goal_state>
-				<score>2.69313067319763322e+00</score>
+				<score>1.79595588900874542e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32621,31 +32621,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.76928408064948495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.20164439980271112e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.46008516150642342e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.04058027148479781e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>5.45997028773915094e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>8.14185369808875514e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.79452965264485509e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32653,34 +32653,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.66269106656973942e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>-2.64469545314780008e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>1.42319641651896656e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>7.40366050372893270e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>6.98353796952216999e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>-1.49167566094834420e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.49989097034685304e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01336339798945607e+00</score>
+				<score>1.88431625660899688e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32711,31 +32711,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.76928408064948495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>-1.20164439980271112e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>1.46008516150642342e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>6.04058027148479781e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>5.45997028773915094e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>8.14185369808875514e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.79452965264485509e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32743,34 +32743,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.66062403289402316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>-2.65477796891422479e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>1.58212279073120499e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>7.49794198797010814e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>6.65687007730906499e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-1.47273201337013132e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.66903360872312567e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88489552071470179e+00</score>
+				<score>1.80415169927687857e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32801,31 +32801,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68304180521979796e+00</second>
+						<second>-1.55539227767475885e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.53365607891304689e+00</second>
+						<second>-2.85148083581384437e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91963070841924233e+00</second>
+						<second>1.57282428920260786e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47098096580177762e+00</second>
+						<second>8.80080012165241010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.76847589017741891e+00</second>
+						<second>7.99631797348561379e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.64281535957950764e+00</second>
+						<second>-2.95885584774935428e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91448193145372647e+00</second>
+						<second>1.43981037091917718e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32833,34 +32833,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76398657928587554e+00</second>
+						<second>-1.57059176463526540e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60920923447049757e+00</second>
+						<second>-2.42133243165460837e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71383381515993194e+00</second>
+						<second>1.81048188105130103e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54305638368413778e+00</second>
+						<second>8.09883160482723019e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.71059951897959728e+00</second>
+						<second>6.71677967528008013e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74106147689688129e+00</second>
+						<second>-1.73041808739986647e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82038492126933282e+00</second>
+						<second>1.82027031739715905e+00</second>
 					</item>
 				</goal_state>
-				<score>2.64604503973686933e+00</score>
+				<score>1.64722140245415399e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32891,31 +32891,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.84889058159822972e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.37377523809291513e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.77611424582722033e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>5.66199474331968600e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>1.38082845743625782e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.28015905489702808e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>1.70873054284765424e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32923,34 +32923,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-1.05826657479549024e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.59341907889505263e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>2.70809001247425130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>7.51608928851427022e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-9.66198790434753096e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>1.91441929149645507e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39748128924333859e+00</score>
+				<score>1.51605550532738720e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32981,31 +32981,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33013,34 +33013,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>1.91979998757461501e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.36293310252658717e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>-1.58707178877744859e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>2.64407191835180744e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>3.10531015129618915e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>1.86108204610146921e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>-1.95015299191684210e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24219973155004393e+00</score>
+				<score>1.45528142982558312e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33071,31 +33071,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33103,34 +33103,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>1.91877472579746033e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.60665197452548547e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>-1.58164763926721474e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>3.15063104748889600e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>3.06251189019865411e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>1.62271496065734389e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>-1.92770280893417167e+00</second>
 					</item>
 				</goal_state>
-				<score>2.26450638514073832e+00</score>
+				<score>1.48837154892444201e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33161,31 +33161,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.81485686817442171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-4.60564625849124235e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.33181986507492289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>5.19620962085519222e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>4.79586093391573931e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>1.59400672102327834e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.74775223198996277e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33193,34 +33193,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67310653540599996e+00</second>
+						<second>-1.73411285983508834e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.26459961235604407e-01</second>
+						<second>-2.03865056765842489e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46233704380274832e+00</second>
+						<second>1.44885381089299403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33736209359702629e-01</second>
+						<second>6.52030364034892229e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.79260708506280508e-01</second>
+						<second>5.98104978624340533e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.50301554233342588e-02</second>
+						<second>-2.90209240080180550e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68232513744266665e+00</second>
+						<second>1.68239044130649207e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77278060301976348e+00</score>
+				<score>1.74236930175609539e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33251,31 +33251,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71470172889414507e+00</second>
+						<second>-1.81485686817442171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.26526806032483197e-02</second>
+						<second>-4.60564625849124235e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46683742590182065e+00</second>
+						<second>1.33181986507492289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.76315635410505656e-01</second>
+						<second>5.19620962085519222e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.24458336218553844e-01</second>
+						<second>4.79586093391573931e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55751716007980795e-01</second>
+						<second>1.59400672102327834e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79451859098775546e+00</second>
+						<second>1.74775223198996277e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33283,34 +33283,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67187990745811677e+00</second>
+						<second>-1.73875084788956835e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.39714242885946877e-02</second>
+						<second>-1.80545094238893700e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58685812590623043e+00</second>
+						<second>1.57440970966187965e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.15785086422579653e-01</second>
+						<second>6.38834376232231937e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.51215462748223173e-01</second>
+						<second>5.60421349989624340e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.60682084978718481e-02</second>
+						<second>2.19904005511120139e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84022826065002842e+00</second>
+						<second>1.84032542749961014e+00</second>
 					</item>
 				</goal_state>
-				<score>2.52335750530583924e+00</score>
+				<score>1.58934051318802810e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33341,31 +33341,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.76928408064948495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.20164439980271112e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.46008516150642342e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.04058027148479781e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>5.45997028773915094e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>8.14185369808875514e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.79452965264485509e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33373,34 +33373,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.65739679106151261e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>-1.88878980597395496e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>1.80757402692822455e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>6.69045268086255085e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>5.48938745837544317e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>-4.15898263624886466e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.99583227157884635e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21805584198547034e+00</score>
+				<score>1.38588037272938724e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33431,31 +33431,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.90738882400318444e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.33099285631573339e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.62320284700062900e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>3.01906302293365736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-2.82548700180940589e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-1.23671183688667985e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.95032586629972160e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33463,34 +33463,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.91950655617126786e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-9.72613049579397981e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.61837810911196489e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>1.74801919483302731e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-1.11793179218589986e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-9.12364844946224940e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>2.10140356571002762e+00</second>
 					</item>
 				</goal_state>
-				<score>1.91392628560236422e+00</score>
+				<score>1.20140941533909584e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33521,31 +33521,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33553,34 +33553,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48355791314392116e+00</second>
+						<second>1.90579056788817103e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81373189601179874e+00</second>
+						<second>-1.38435865916136902e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.87278810648397231e-01</second>
+						<second>-1.53052332481265640e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.77479405340243312e-01</second>
+						<second>1.54664290868865573e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.97817092519894000e-01</second>
+						<second>2.87736829539842009e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.69389238266661479e+00</second>
+						<second>1.78437676463316319e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14040185681513728e+00</second>
+						<second>-2.14038475933708172e+00</second>
 					</item>
 				</goal_state>
-				<score>1.58088281260714747e+00</score>
+				<score>1.12379018663061048e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33611,31 +33611,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>1.90097237066341318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.56697166930909204e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>-1.62718827773318275e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>3.61580130843097480e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>3.06169137062515695e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>1.67579336991385786e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>-1.92778017998578699e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33643,34 +33643,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54146591030873847e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.24629259158364958e-01</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44684139822691016e+00</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38291662796365422e+00</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04354123181146452e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10510314143936172e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82090852553084082e+00</score>
+				<score>1.17288764070564530e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33701,31 +33701,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78637060988341356e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04721522689026075e-01</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71036451288940472e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.56763737192674513e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.13248621962688190e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.58036920870392184e-01</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19784145324850666e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33733,34 +33733,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75710114345983048e+00</second>
+						<second>-1.84548381190204069e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.78689810643983138e-03</second>
+						<second>-1.16733338537820724e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55873961545851691e+00</second>
+						<second>1.55068962744091055e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.85552513694617471e-01</second>
+						<second>4.58505044421071650e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.43777858502480393e-01</second>
+						<second>3.92177054666057623e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.25562014398732524e-01</second>
+						<second>6.80270545055013248e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562695644893926e+00</second>
+						<second>1.96567627160652902e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22036763216342559e+00</score>
+				<score>1.40461288153039765e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33791,31 +33791,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66925791581053873e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.03095193771310256e-02</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58707722126778106e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.18505174331760643e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54922146744453260e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.92168160214446004e-02</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84023930436279448e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33823,34 +33823,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.76924436071795954e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>-1.09549920306726889e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.77051983723946460e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>4.67945073427420921e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>3.83386786918795908e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>5.42597192116983998e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>2.12705987775569616e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84908834710682335e+00</score>
+				<score>1.16638007844764052e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33881,31 +33881,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74464655436084648e+00</second>
+						<second>-1.91950655617126786e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.58802106428551483e-02</second>
+						<second>-9.72613049579397981e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55839273722332639e+00</second>
+						<second>1.61837810911196489e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00102572895211406e-01</second>
+						<second>1.74801919483302731e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.62897973861232526e-01</second>
+						<second>-1.11793179218589986e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.44420032308462487e-01</second>
+						<second>-9.12364844946224940e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96569910964345551e+00</second>
+						<second>2.10140356571002762e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33913,34 +33913,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24628822490843394e+00</second>
+						<second>-1.85283982000333025e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.51153637677357144e-01</second>
+						<second>-8.69115006321319661e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91898034040003695e+00</second>
+						<second>1.68269329231352627e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.02532876186664512e-01</second>
+						<second>6.00860119249263872e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.85962431984410803e-01</second>
+						<second>-3.07575910207455394e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70931425880790488e-01</second>
+						<second>-8.59653758090621833e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24541234239523213e+00</second>
+						<second>2.24542944837609371e+00</second>
 					</item>
 				</goal_state>
-				<score>1.41428471295579272e+00</score>
+				<score>9.46260177645057016e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -34061,31 +34061,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34093,34 +34093,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78755704503224244e+00</second>
+						<second>1.73059441372875944e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40983277476643387e+00</second>
+						<second>-1.63560327302609543e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.51296694592313496e+00</second>
+						<second>-1.64948195692009603e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.23169848335719712e-01</second>
+						<second>4.00432284766414237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.34067548553156191e-01</second>
+						<second>2.59200916283703897e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.45057298933861367e+00</second>
+						<second>1.60360807059138777e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23616801111425101e+00</second>
+						<second>-2.23624999183108608e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49453310398337824e+00</score>
+				<score>9.34451926897222479e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34151,31 +34151,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>1.71532157304109645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-2.19444806960472361e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>-8.87096666763956931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>2.56496469136614058e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>-2.50994284845416482e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-9.44423488227924129e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>2.13513061619105882e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34183,34 +34183,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>1.77261313090608064e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>-2.89342579909963815e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>-9.07542420291535978e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>2.68316740441473911e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>-2.60020449991518010e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>-2.02611456937857370e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>2.19642176378927134e+00</second>
 					</item>
 				</goal_state>
-				<score>1.63222029782648814e+00</score>
+				<score>1.02655989479711204e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34241,31 +34241,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34273,34 +34273,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61527761859090879e+00</second>
+						<second>-1.90264896318182086e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.32872535146387183e-01</second>
+						<second>6.57270767267345568e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40664019055545486e+00</second>
+						<second>1.53545178771909874e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46575382306285995e+00</second>
+						<second>2.96773545378543058e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.77307290490046543e-01</second>
+						<second>2.79327160038403521e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.39456950429085946e+00</second>
+						<second>2.09615960977245719e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05347802109407063e+00</second>
+						<second>2.05339950421760076e+00</second>
 					</item>
 				</goal_state>
-				<score>1.87907011003960323e+00</score>
+				<score>1.26521113903071358e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34331,31 +34331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.91979999266212542e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>-6.30488681843844323e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.42639204092203564e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>-2.99888091296726444e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>-2.74662470148053561e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>-2.10321886536636804e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>1.95333231411720609e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34363,34 +34363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78637060988341356e+00</second>
+						<second>-1.88569456693310178e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04721522689026075e-01</second>
+						<second>-1.27689404412244328e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71036451288940472e+00</second>
+						<second>1.72509439126033937e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.56763737192674513e-01</second>
+						<second>8.71720845430538349e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.13248621962688190e-01</second>
+						<second>3.05015935422342996e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.58036920870392184e-01</second>
+						<second>-8.95491478132939417e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19784145324850666e+00</second>
+						<second>2.19777862966686399e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64889685136996134e+00</score>
+				<score>1.04847448173603322e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -34691,31 +34691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>-1.91856842075775336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>-3.08712862530746701e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>9.10971036806496159e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>-2.95712469166303782e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>-4.83967540478665512e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>2.89009279576365641e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>-2.19433807291058125e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34723,34 +34723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>-1.91354526929908841e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-2.96699999823420724e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>-8.96393047011330713e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>3.10055032447312451e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>3.10864217347555627e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>-3.00111229863312090e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>-2.23354773169291532e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52146948425756112e+00</score>
+				<score>9.64922798384794528e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34781,31 +34781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.27651665749751125e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.30212768513526611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.48197394159179130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.37106221436600761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.11407491644512760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.74971646012369497e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34813,34 +34813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74113936401921787e+00</second>
+						<second>-1.91972029458958060e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.87954735110198912e-01</second>
+						<second>-2.49591751366800667e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.27724270996238354e+00</second>
+						<second>1.53639978170197700e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58011856423481412e+00</second>
+						<second>-2.49592507343458697e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.23467396762995785e-01</second>
+						<second>-2.27502564504416999e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.22808888305042796e+00</second>
+						<second>-1.46573195987646621e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05201743406381443e+00</second>
+						<second>2.05185448684851401e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83344902300973045e+00</score>
+				<score>1.27183485605810026e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34871,31 +34871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91943590458013325e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>2.62988106306290825e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.52385994771427113e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-2.95359144956567343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.21234487708968752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>1.34505221995282115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.96929460238571985e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34903,34 +34903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76507176844913860e+00</second>
+						<second>-1.87986197528302590e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.43230634582450922e-01</second>
+						<second>9.32661459307877611e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.70219748559920148e+00</second>
+						<second>1.73136173236753610e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.75468562789537152e+00</second>
+						<second>-1.20525522543118671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.68148189665566505e+00</second>
+						<second>-7.27036662117993421e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.08926704070259495e-01</second>
+						<second>4.02518756017820542e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19857489548238449e+00</second>
+						<second>2.19857693718565894e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64071162595965658e+00</score>
+				<score>1.04720337431637597e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -35263,34 +35263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91352435221176487e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.86907401090920078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-8.96409896699534081e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-3.09807034296986616e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-3.10552799571956850e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-1.50529702833704759e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.23340700035278505e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.64511223828612568e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35321,31 +35321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.88268840801550197e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>3.40439123886749961e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.66837551150107855e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>1.03912936643083029e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>2.13628065931490030e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>3.97112986077753638e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>2.19858366183026543e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35353,34 +35353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76918515783345631e+00</second>
+						<second>-1.91943590458013325e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.16873408255978202e-02</second>
+						<second>2.62988106306290825e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56584339162334074e+00</second>
+						<second>1.52385994771427113e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57225136447145841e+00</second>
+						<second>-2.95359144956567343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61958484224720634e+00</second>
+						<second>-2.21234487708968752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.99527848367228533e-01</second>
+						<second>1.34505221995282115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.96939053005501497e+00</second>
+						<second>1.96929460238571985e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21784973568084132e+00</score>
+				<score>1.40687276939516853e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35411,31 +35411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.76645297871543994e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>5.34486734121958684e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.71349205830567564e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-5.95183008329698615e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-4.27051143571147818e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>4.02152980477099298e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.82325660290466085e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35443,34 +35443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.85507357889085078e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>2.95044344945019743e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.73494182554101672e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>-3.33531372221608613e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>-1.93230193836121528e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>1.63563080988759074e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>2.12630254202994262e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85605535014282252e+00</score>
+				<score>1.16989639816752325e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35501,31 +35501,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91943590458013325e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.62988106306290825e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.52385994771427113e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.95359144956567343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.21234487708968752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.34505221995282115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.96929460238571985e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35533,34 +35533,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.84245461901871166e+00</second>
+						<second>-1.77752218914666948e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04194671261787009e+00</second>
+						<second>5.35594228588841204e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47154084714350342e+00</second>
+						<second>1.91970564671177235e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.02006896370979705e+00</second>
+						<second>-2.91890252112437354e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.58064476397714693e-01</second>
+						<second>2.00885254451160164e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.97512776275998991e+00</second>
+						<second>4.17382916141873950e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598621125695619e+00</second>
+						<second>2.24590863111924266e+00</second>
 					</item>
 				</goal_state>
-				<score>1.46433250340691146e+00</score>
+				<score>9.52466397775718343e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -35681,31 +35681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>1.91959300449863335e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-1.28719460706379230e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.53802395200535602e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>2.76420216320165268e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.90169224967037476e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>-1.37625898048339113e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.01025368267273041e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35713,34 +35713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82360175648419687e+00</second>
+						<second>1.81421632788236775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.80198631524536568e+00</second>
+						<second>-1.36181220582870566e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41685676848750575e+00</second>
+						<second>-1.44647164537252415e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.88031591604325721e+00</second>
+						<second>2.86095561683118094e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.63110363736412101e+00</second>
+						<second>-2.62446325766020960e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.80260502746759488e+00</second>
+						<second>-1.37372105583749149e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23428557187584342e+00</second>
+						<second>2.23427595955820646e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49885286916037175e+00</score>
+				<score>9.48378270324139044e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35771,31 +35771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>-1.76340300932831817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>2.23918748686015023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>1.10598400589517243e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>-2.39358882999928735e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>-7.38946357585954949e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>2.19495764180682479e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>-1.87150095554267715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35803,34 +35803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85328912498311049e+00</second>
+						<second>-1.91856842075775336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.29080996963506101e-02</second>
+						<second>-3.08712862530746701e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79506499438766687e-01</second>
+						<second>9.10971036806496159e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46430607230658105e-01</second>
+						<second>-2.95712469166303782e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82430149653353846e+00</second>
+						<second>-4.83967540478665512e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14127976856162805e+00</second>
+						<second>2.89009279576365641e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19434577502995287e+00</second>
+						<second>-2.19433807291058125e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65731622919481536e+00</score>
+				<score>1.02401156305832131e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35861,31 +35861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.74693297531941849e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>3.79103265655176713e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.29168148797388782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-5.61344665600463699e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-5.79750985280498843e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>2.39225589632100166e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>1.42475835253436012e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35893,34 +35893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71670712376820056e+00</second>
+						<second>-1.81461359195026950e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.79003587336505066e-01</second>
+						<second>3.17800180549092259e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45375954288232201e+00</second>
+						<second>1.41710118535430474e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46477275640420990e+00</second>
+						<second>-5.17876464592737396e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51932267323400350e+00</second>
+						<second>-4.76548908017365991e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03120276869565509e-03</second>
+						<second>1.50531357010859790e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68403153904001113e+00</second>
+						<second>1.68401477556083479e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77861126005283010e+00</score>
+				<score>1.74522532108407680e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35951,31 +35951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.89006999257801667e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.94157730836888509e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.41866263657776970e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-3.79169849508065149e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-3.30336905603777209e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.39917385442913766e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.80320758024975469e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35983,34 +35983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73925868115602777e+00</second>
+						<second>-1.86276796520798915e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.95930118755284877e+00</second>
+						<second>3.69856741868815453e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57284722306790581e+00</second>
+						<second>1.51684807570517100e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50288142124191326e+00</second>
+						<second>-4.42469711861834869e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58147363065314694e+00</second>
+						<second>-3.62933975797751662e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149999579694716e+00</second>
+						<second>2.10460781383860929e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83804557518041944e+00</second>
+						<second>1.83808528308782404e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53970747685909259e+00</score>
+				<score>1.59772510632841924e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36041,31 +36041,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.91979137982766113e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>1.76082784252450691e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.42986822081706721e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-3.04833916940697669e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-2.59937724603925169e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>3.83473209219143338e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.89045800957812560e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36073,34 +36073,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.62760127502048668e+00</second>
+						<second>-1.79484660394383044e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41397017045672146e-01</second>
+						<second>4.01020475920903396e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.81154004884962960e+00</second>
+						<second>1.74411836794671982e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44709615825252147e+00</second>
+						<second>-5.16612287704845574e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54991212224829322e+00</second>
+						<second>-3.45306155227997735e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.11878768455815824e-04</second>
+						<second>2.42164631806743996e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99617595192988895e+00</second>
+						<second>1.99613260881332000e+00</second>
 					</item>
 				</goal_state>
-				<score>2.20858460213500596e+00</score>
+				<score>1.38777188049252931e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36131,31 +36131,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36163,34 +36163,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21457652806431060e+00</second>
+						<second>-1.90509089002319643e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.45865043020349422e-01</second>
+						<second>9.37905573316270225e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-2.36681432456512408e-01</second>
+						<second>1.66576255842348075e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.10736582538653439e-01</second>
+						<second>-2.25842274907401053e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66004874558748305e+00</second>
+						<second>8.34269476046092667e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.54258151607269056e+00</second>
+						<second>8.54707547956793268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10292606190553499e+00</second>
+						<second>2.10305163386111049e+00</second>
 					</item>
 				</goal_state>
-				<score>1.45078837635414915e+00</score>
+				<score>1.19927116066640041e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36221,31 +36221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.87233465475948413e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.25142140040781569e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.70475989733042899e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.97359943828270257e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-2.16874911276023652e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.15957522395458468e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.68210894418714973e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36253,34 +36253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80902140764373498e+00</second>
+						<second>-1.89361985398684651e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13647809330280403e+00</second>
+						<second>1.33235013192359175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.82257713740364036e+00</second>
+						<second>1.59004357106369354e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.90797684858574079e-01</second>
+						<second>-2.02200477724989364e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.69108102408746075e-01</second>
+						<second>2.50942327465248360e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.91534008625388763e-01</second>
+						<second>1.27747315132098027e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14114766393780620e+00</second>
+						<second>2.14109265945981253e+00</second>
 					</item>
 				</goal_state>
-				<score>1.62385540630320691e+00</score>
+				<score>1.12363485237570684e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36311,31 +36311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36343,34 +36343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66595129956587873e+00</second>
+						<second>1.91973973664914088e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.62268099645884040e-01</second>
+						<second>-1.39999184175704761e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.26890886087950161e-01</second>
+						<second>-1.45769052105406782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.10833426446853456e-01</second>
+						<second>2.91732516635711381e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64436515517895199e+00</second>
+						<second>-2.86775093309297002e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87543536154473545e+00</second>
+						<second>-1.43513408565227141e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09849759934938618e+00</second>
+						<second>2.09831494390119833e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84856567158747032e+00</score>
+				<score>1.19707869181012561e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36401,31 +36401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.81741002199385226e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>2.75913791343190218e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.32452628582411291e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-4.86514529467767964e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-4.67415528678224834e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>1.06563364323105925e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.62085031533811130e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36433,34 +36433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66037125008114206e+00</second>
+						<second>-1.75270672525152471e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63778970879877062e-01</second>
+						<second>4.02567050256378900e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42157645016142431e+00</second>
+						<second>1.37959787053726868e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39863131931057483e+00</second>
+						<second>-5.86700814593263842e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.44037573262350671e+00</second>
+						<second>-5.78579731750741511e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.49784648322292213e-01</second>
+						<second>2.68341927640365074e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.49548546011881012e+00</second>
+						<second>1.49546870527981812e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01154923745536252e+00</score>
+				<score>1.88803359200953508e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36491,31 +36491,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.81741002199385226e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>2.75913791343190218e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.32452628582411291e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-4.86514529467767964e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-4.67415528678224834e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>1.06563364323105925e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>1.62085031533811130e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36523,34 +36523,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66071696033655192e+00</second>
+						<second>-1.76249794205853094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.66516941556673270e-01</second>
+						<second>4.14685534420381641e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58218807684669871e+00</second>
+						<second>1.53578085543244747e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39207579951939486e+00</second>
+						<second>-6.07536823046907370e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47619092661752882e+00</second>
+						<second>-5.34392257733919518e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48411726118480192e-01</second>
+						<second>2.75676043539893278e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.66847590820878522e+00</second>
+						<second>1.66852529594088472e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87850495928771144e+00</score>
+				<score>1.80951888797601629e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36581,31 +36581,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56576966764727238e-01</second>
+						<second>-1.85757080691041576e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30007076503686547e+00</second>
+						<second>3.01139359957297126e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16462994665354769e+00</second>
+						<second>1.73298396012540179e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>-3.28063764289420801e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.36094895155904849e+00</second>
+						<second>-1.86621892662908684e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01437123888323422e+00</second>
+						<second>1.71195568871671339e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.60004221478434805e+00</second>
+						<second>2.12635050095955291e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36613,34 +36613,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.41071193222215313e-02</second>
+						<second>-1.76645297871543994e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.26431816820358334e+00</second>
+						<second>5.34486734121958684e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07342913624144876e+00</second>
+						<second>1.71349205830567564e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14149994031591451e+00</second>
+						<second>-5.95183008329698615e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.32084791690980730e+00</second>
+						<second>-4.27051143571147818e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11367807974205757e+00</second>
+						<second>4.02152980477099298e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82312702532035775e+00</second>
+						<second>1.82325660290466085e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84008143270806390e+00</score>
+				<score>1.65273708853924922e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36671,31 +36671,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.90509089002319643e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>9.37905573316270225e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.66576255842348075e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>-2.25842274907401053e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>8.34269476046092667e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>8.54707547956793268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>2.10305163386111049e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36703,34 +36703,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80357787001626835e+00</second>
+						<second>-1.91866038634051161e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.33994788570438228e+00</second>
+						<second>1.04510601133566539e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.80030099654551479e+00</second>
+						<second>1.59826132998273307e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.62194918536618848e+00</second>
+						<second>-2.74734282726290913e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.91323955900366460e+00</second>
+						<second>-7.49439529081859096e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47367520452623602e+00</second>
+						<second>9.51782504831886533e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91964872262181818e+00</second>
+						<second>1.91953510589634035e+00</second>
 					</item>
 				</goal_state>
-				<score>2.10798946940520171e+00</score>
+				<score>1.50802309929523842e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36761,31 +36761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>1.91973973664914088e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.39999184175704761e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>-1.45769052105406782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>2.91732516635711381e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-2.86775093309297002e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>-1.43513408565227141e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>2.09831494390119833e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36793,34 +36793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75448154560338709e+00</second>
+						<second>1.91966279087073666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.10005141276530116e+00</second>
+						<second>-1.78130457614295801e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.90726415615026190e+00</second>
+						<second>-1.58777775009438216e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56594157008385348e+00</second>
+						<second>2.87811354889077142e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.05647911197432354e+00</second>
+						<second>-3.10170818042736629e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.24145473656550420e+00</second>
+						<second>-1.86355456351316739e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95457673655683672e+00</second>
+						<second>1.95440424805045843e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22355893659825643e+00</score>
+				<score>1.44824993963137166e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36851,31 +36851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>-1.38760209889569519e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>-1.59666257864280992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>2.75431970198732001e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>-3.09013511167980326e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>-1.48376342534719030e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>1.84170789554129244e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36883,34 +36883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>1.91979732895740440e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-1.52999278239830305e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.57907463353222144e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>2.82849738947147245e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-3.06981523929826405e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>-1.61699324584713477e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>1.91962271523347217e+00</second>
 					</item>
 				</goal_state>
-				<score>2.29844892183925120e+00</score>
+				<score>1.50184639528082808e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36941,31 +36941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36973,34 +36973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>-1.59039370387661450e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>5.04399258808676310e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>1.16151101258342004e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>-6.49987224892857873e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>-7.85597353024509615e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>4.72567949070289206e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>9.49800715790804384e-01</second>
 					</item>
 				</goal_state>
-				<score>2.65006608683111011e+00</score>
+				<score>1.65630667160837769e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37031,31 +37031,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.74693297531941849e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>3.79103265655176713e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.29168148797388782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-5.61344665600463699e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-5.79750985280498843e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>2.39225589632100166e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.42475835253436012e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37063,34 +37063,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.58819752554857097e+00</second>
+						<second>-1.66991315551316855e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.35258474703069631e-01</second>
+						<second>4.80879004467967275e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35645458531869978e+00</second>
+						<second>1.31442752097427706e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33729222575486473e+00</second>
+						<second>-6.42284485748376488e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.34292146094920062e+00</second>
+						<second>-6.99126632535935100e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.21707441816662221e-01</second>
+						<second>4.14264998619850500e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22697069073171572e+00</second>
+						<second>1.22682607485489781e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06457938100477811e+00</score>
+				<score>1.91743398302957058e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37121,31 +37121,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37153,34 +37153,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.69614150069549874e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>5.06432102105622395e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.50808077848526234e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-6.70663532885462765e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-6.39098663974608350e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>4.38374512775019209e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.44347979290515260e+00</second>
 					</item>
 				</goal_state>
-				<score>3.16765444436430510e+00</score>
+				<score>1.98523171729653614e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37211,31 +37211,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.80452172515614429e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>4.82846140695784853e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.50690841335823755e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-5.34508968321917299e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-4.74765561322760432e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>3.42511104532839949e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.66834689392544777e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37243,34 +37243,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64263555776755754e+00</second>
+						<second>-1.71382753222648576e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64667024761761915e+00</second>
+						<second>6.11650045681486954e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.72457184368441907e+00</second>
+						<second>1.67548846289941600e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.61828225781430612e-01</second>
+						<second>-6.62363725006069659e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51961732549067596e+00</second>
+						<second>-5.41780006572172734e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.60912044417067956e-01</second>
+						<second>5.43861719734553883e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.60009435741077888e+00</second>
+						<second>1.60021691042463843e+00</second>
 					</item>
 				</goal_state>
-				<score>3.05740170523157717e+00</score>
+				<score>1.91804970628983357e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37301,31 +37301,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>-1.83348204546151261e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>1.34542470978890716e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>1.80043909217263964e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>-5.93704141362772164e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>-1.42495262996328781e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>1.25297593773834293e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>1.71104111817029558e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37333,34 +37333,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.88878497074590768e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>1.10664598571398276e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.57301424038013571e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>-3.51685597618394963e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>-2.59927003693214698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>1.01365981817149864e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>1.68115944058064559e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87498980973320117e+00</score>
+				<score>1.84134809890156792e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37391,31 +37391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37423,34 +37423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91861976745157703e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.35235015153463767e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.61521987251620058e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-3.82870302958889741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-1.92162251312154142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.26305907998108236e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.68205432588022008e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>1.84105518333425200e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37481,31 +37481,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37513,34 +37513,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91738291380812420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.50224007179300401e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.65451086874754938e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.21174564776181759e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.20687611234278347e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.41069343229110511e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71099043416156626e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71467833239565692e+00</score>
+				<score>1.79535530600426096e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -37661,31 +37661,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.43153606072611095e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.68941400944426467e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>9.57695072155978933e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.85696394313802027e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-9.42672591543108895e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.07341457730388057e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90462717538369508e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37693,34 +37693,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39776116547487450e+00</second>
+						<second>-1.42926702029359354e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.46742538136349676e-01</second>
+						<second>6.12104188540014249e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01345139506047777e+00</second>
+						<second>9.94804114750080348e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23123050539687284e+00</second>
+						<second>-7.30697085475807362e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12332802065480664e+00</second>
+						<second>-9.80503910415455482e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72487916088626458e-01</second>
+						<second>7.02206673577975948e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26449463597276868e-01</second>
+						<second>4.26450014797590260e-01</second>
 					</item>
 				</goal_state>
-				<score>1.31147574097958652e+00</score>
+				<score>8.36900073931876876e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37751,31 +37751,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37783,34 +37783,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>-1.57306856276921181e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>5.79409569662574619e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>1.23948651255222742e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>-7.40943503815006288e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>-8.47202893221417619e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>6.35025584158116496e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>8.49934932710037172e-01</second>
 					</item>
 				</goal_state>
-				<score>2.53630813439910208e+00</score>
+				<score>1.63739727855590850e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37841,31 +37841,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>1.60737385704258062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>-2.47196051747263557e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>-1.61115315439674456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>2.08565371077568917e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>2.29717662647831977e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>-2.06035670193928189e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>7.85891347050963862e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37873,34 +37873,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>1.59152370992342140e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>-2.61257966702540489e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>-1.45783486703910792e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>2.27358183265915814e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>2.33053324329082034e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>-2.50984962773922460e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.07740522635630676e+00</second>
 					</item>
 				</goal_state>
-				<score>3.02662676986478862e+00</score>
+				<score>1.95860812832635012e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37931,31 +37931,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48830764276185601e+00</second>
+						<second>-1.71382753222648576e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.48834496702776997e+00</second>
+						<second>6.11650045681486954e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65183174912158748e+00</second>
+						<second>1.67548846289941600e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.00106371924749715e+00</second>
+						<second>-6.62363725006069659e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29731926155392241e+00</second>
+						<second>-5.41780006572172734e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.09836415129911091e+00</second>
+						<second>5.43861719734553883e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90826130608407118e-01</second>
+						<second>1.60021691042463843e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37963,34 +37963,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.66986221423874825e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>6.90053856378068042e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.59204165117426277e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-8.34605542216158347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-7.08064119484427268e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>7.74634487576996489e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.18885777888515354e+00</second>
 					</item>
 				</goal_state>
-				<score>3.28915446269859846e+00</score>
+				<score>2.06958280447223808e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38021,31 +38021,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.66986221423874825e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>6.90053856378068042e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.59204165117426277e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-8.34605542216158347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-7.08064119484427268e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>7.74634487576996489e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.18885777888515354e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38053,34 +38053,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80997196953296724e+00</second>
+						<second>-1.68304021847771823e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.13396736033743251e+00</second>
+						<second>7.58706155662025594e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62934275283419061e+00</second>
+						<second>1.74387237442897547e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.43913050759826389e+00</second>
+						<second>-9.44176909666115671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57578701736583193e+00</second>
+						<second>-6.60358574178019797e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.10567519364315547e+00</second>
+						<second>9.16747584239542945e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22484651217601614e+00</second>
+						<second>1.22483474277359083e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17211517225196893e+00</score>
+				<score>2.09166608660011077e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38111,31 +38111,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.83348204546151261e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.34542470978890716e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.80043909217263964e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-5.93704141362772164e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.42495262996328781e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.25297593773834293e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71104111817029558e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38143,34 +38143,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91654321014781459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.33797624201311449e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.59292493439837957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-4.74041894449619194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-4.16420071710977502e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.29644689467551011e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.32803904501623404e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25818158883596531e+00</score>
+				<score>2.09553354158149352e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -38741,31 +38741,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>1.60737385704258062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>-2.47196051747263557e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>-1.61115315439674456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>2.08565371077568917e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>2.29717662647831977e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>-2.06035670193928189e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>7.85891347050963862e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38773,34 +38773,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>1.55039769876709621e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>-2.49335830466708153e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>-1.41050778771040242e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>2.10959868196802569e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>2.18171399671336141e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>-2.02680323101411730e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.79007639214927949e-01</second>
 					</item>
 				</goal_state>
-				<score>1.68196193634369906e+00</score>
+				<score>1.15332833726483355e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38831,31 +38831,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54916048664779593e+00</second>
+						<second>1.55031770928719159e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49844395243749950e+00</second>
+						<second>-2.49344751733118875e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41121153989575610e+00</second>
+						<second>-1.41051759643291841e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03756026607938479e+00</second>
+						<second>2.10911561137799453e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18068408915521417e+00</second>
+						<second>2.18161757432899073e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11434521775308237e+00</second>
+						<second>-2.02656037653449328e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.78707166769210490e-01</second>
+						<second>4.78707449549079900e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38863,34 +38863,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>1.60737385704258062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>-2.47196051747263557e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>-1.61115315439674456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>2.08565371077568917e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>2.29717662647831977e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>-2.06035670193928189e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>7.85891347050963862e-01</second>
 					</item>
 				</goal_state>
-				<score>2.47626478979971631e+00</score>
+				<score>1.74419937122168300e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -40721,31 +40721,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36135145667084156e+00</second>
+						<second>-1.49939149506772273e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64510607928626629e-01</second>
+						<second>-2.19207510247746484e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61588372366334565e-01</second>
+						<second>9.40571052046941136e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.45874687191908037e-01</second>
+						<second>7.76385816250054095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.89909758592306788e-01</second>
+						<second>8.28938824340800018e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37088245451391244e-01</second>
+						<second>-1.89814483432983794e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257833395275048e-01</second>
+						<second>8.52573894969098522e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -40753,34 +40753,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36236351439997017e+00</second>
+						<second>-1.38006339822405955e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08646752223005028e-01</second>
+						<second>-3.84461447651885058e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74590747139882252e-01</second>
+						<second>9.68219915581197577e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87291978619487920e-01</second>
+						<second>9.02836397394061296e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02823731815388220e+00</second>
+						<second>1.00691814173241867e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69571325828563069e-01</second>
+						<second>-5.82671298825525263e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56067885625283997e-01</second>
+						<second>4.56010059235428034e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35685204215835742e+00</score>
+				<score>8.52543464869693485e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41081,31 +41081,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.50253060887114165e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>-2.75556103647820128e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>1.14719456367389161e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>8.62605881452942147e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>8.81465786539034957e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-3.12449399000898076e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>9.53263224800124154e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41113,34 +41113,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36135145667084156e+00</second>
+						<second>-1.37431917797776615e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64510607928626629e-01</second>
+						<second>-3.16691988037028471e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61588372366334565e-01</second>
+						<second>8.57511025394904536e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.45874687191908037e-01</second>
+						<second>8.84665293873395764e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.89909758592306788e-01</second>
+						<second>9.72217874548274463e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37088245451391244e-01</second>
+						<second>-4.47273199047822534e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257833395275048e-01</second>
+						<second>4.69168604993346117e-01</second>
 					</item>
 				</goal_state>
-				<score>1.25329798991943786e+00</score>
+				<score>7.86772744909259442e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41171,31 +41171,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.66322775790114852e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>-1.24037727128100211e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>1.16662790702922070e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>6.86213253455757344e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>6.74186539669794693e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>3.73604692965325003e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>1.37504010172974422e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41203,34 +41203,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49132019866036036e+00</second>
+						<second>-1.51766219390581747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54253477600731304e-01</second>
+						<second>-3.05185502647270568e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15054332515347069e+00</second>
+						<second>1.14226183756638244e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87164314367234197e-01</second>
+						<second>8.27784167401993121e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94533768256409623e-01</second>
+						<second>8.63190462215429277e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02819284496538832e-01</second>
+						<second>-3.25895577082603471e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577580936474156e-01</second>
+						<second>9.53309564321128344e-01</second>
 					</item>
 				</goal_state>
-				<score>2.56203201461366259e+00</score>
+				<score>1.60971539752843340e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41261,31 +41261,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.72138415211871454e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>-1.38966242530340900e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>1.35874021040573023e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.60404558687945453e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>6.19680839554865193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>4.72605648228682715e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.62517038866342567e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41293,34 +41293,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64899454764704778e+00</second>
+						<second>-1.59077333027839551e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75667356055201784e+00</second>
+						<second>-2.86943132172462589e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26185027745481104e+00</second>
+						<second>1.28637437916860620e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46335905409314870e+00</second>
+						<second>7.92073017657252465e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42324171315149872e+00</second>
+						<second>7.91808788463160718e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83593037018853478e+00</second>
+						<second>-2.41203549051378169e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22308800960471209e+00</second>
+						<second>1.22310221460714219e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96781167421309888e+00</score>
+				<score>1.86183197191775479e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41531,31 +41531,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49140078977534207e+00</second>
+						<second>-1.57282433165854352e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54327059552048318e-01</second>
+						<second>-2.58672025068967748e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15044839052523296e+00</second>
+						<second>1.29209508825219910e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87464035894850012e-01</second>
+						<second>8.23908109589281845e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94615692479908353e-01</second>
+						<second>8.13187606870205859e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.03130205520645124e-01</second>
+						<second>-2.24038324435754999e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53261312664367200e-01</second>
+						<second>1.22309419926522955e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41563,34 +41563,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.49939149506772273e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>-2.19207510247746484e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>9.40571052046941136e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>7.76385816250054095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>8.28938824340800018e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>-1.89814483432983794e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>8.52573894969098522e-01</second>
 					</item>
 				</goal_state>
-				<score>2.09136882726456896e+00</score>
+				<score>1.31191079002619226e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41621,31 +41621,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.72138415211871454e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>-1.38966242530340900e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>1.35874021040573023e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.60404558687945453e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>6.19680839554865193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>4.72605648228682715e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.62517038866342567e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41653,34 +41653,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66110631140187404e+00</second>
+						<second>-1.60937626164893666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81899582271532356e+00</second>
+						<second>-2.37059625124782042e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15444144382355574e+00</second>
+						<second>1.17384027599392660e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51833261420991583e+00</second>
+						<second>7.34071662897019084e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46862437408077451e+00</second>
+						<second>7.47326615141193029e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93814903269952898e+00</second>
+						<second>-1.39368388628786033e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21459551553429690e+00</second>
+						<second>1.21429152787082373e+00</second>
 					</item>
 				</goal_state>
-				<score>2.81168540436485559e+00</score>
+				<score>1.76254277963674350e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41711,31 +41711,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>-1.81485686817442171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>-4.60564625849124235e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>1.33181986507492289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>5.19620962085519222e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>4.79586093391573931e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>1.59400672102327834e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>1.74775223198996277e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41743,34 +41743,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.67563283691913600e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>-2.67942609909107066e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>1.32504622689627172e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>6.98423060701464760e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>6.81742804506531574e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>-1.40716928129970525e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.42479203712245051e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98209612723430562e+00</score>
+				<score>1.86704728094805789e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41891,31 +41891,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.49939149506772273e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>-2.19207510247746484e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>9.40571052046941136e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>7.76385816250054095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>8.28938824340800018e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>-1.89814483432983794e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>8.52573894969098522e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41923,34 +41923,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41187604068918326e+00</second>
+						<second>-1.42291385845738305e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.05418518222664293e-01</second>
+						<second>-1.39311460581409641e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.70885814090585564e-01</second>
+						<second>6.69177790044527931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.71787633061046030e-01</second>
+						<second>7.22971055457804157e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.94493670142432773e-01</second>
+						<second>7.72255358548982529e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.19279604451532684e-01</second>
+						<second>-1.31318625539305844e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.74910833977436697e-01</second>
+						<second>5.74900221331326899e-01</second>
 					</item>
 				</goal_state>
-				<score>1.17856570184381404e+00</score>
+				<score>7.38824916407797433e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41981,31 +41981,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.71549469954291367e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>1.05619645677710636e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>8.85440094358336593e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>4.63520193955426318e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>4.02285602588438040e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>2.31788444825865830e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.23907348505551895e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42013,34 +42013,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.62284019665770063e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>-1.90716343633768937e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>9.30714545191495657e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>5.81596378528380531e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>6.37940959190750778e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-6.57119203692470844e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04788261902605173e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32029742004960582e+00</score>
+				<score>1.45539262734513480e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42071,31 +42071,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.81485686817442171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>-4.60564625849124235e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>1.33181986507492289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>5.19620962085519222e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>4.79586093391573931e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>1.59400672102327834e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.74775223198996277e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42103,34 +42103,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73250365272873652e+00</second>
+						<second>-1.70376908905464974e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.91910432206721770e+00</second>
+						<second>-1.79278557007483602e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14889447344846030e+00</second>
+						<second>1.15787920958422097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59656881987393007e+00</second>
+						<second>6.08230408960001134e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57787923731777013e+00</second>
+						<second>6.12266801857534237e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08029447672819723e+00</second>
+						<second>-1.66802025071915057e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.37499735251213950e+00</second>
+						<second>1.37494075727534337e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79881841872992743e+00</score>
+				<score>1.75128501823798133e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42161,31 +42161,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.87953136402282328e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>1.02889652809151882e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.28430607190869228e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>3.91686281389325319e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>3.54140663926493293e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>2.84905160344478825e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.80299564224725994e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42193,34 +42193,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68907342565908980e+00</second>
+						<second>-1.75532046489154947e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.97554533828211437e-02</second>
+						<second>-1.83127861863991548e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36412620592428802e+00</second>
+						<second>1.35087622356989367e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.06242753382350985e-01</second>
+						<second>6.06460743412133185e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.63658836370434657e-01</second>
+						<second>5.69979716496774702e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.73594592947892629e-02</second>
+						<second>4.72026811972884501e-04</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62546866462347261e+00</second>
+						<second>1.62519330276990481e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78049412498447568e+00</score>
+				<score>1.75157311322983705e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42251,31 +42251,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42283,34 +42283,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71470172889414507e+00</second>
+						<second>-1.82348673712323039e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.26526806032483197e-02</second>
+						<second>-1.94578676354838609e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46683742590182065e+00</second>
+						<second>1.44639681136679488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.76315635410505656e-01</second>
+						<second>5.17824658950389427e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.24458336218553844e-01</second>
+						<second>4.59227454205504926e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55751716007980795e-01</second>
+						<second>-7.01350188343145137e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79451859098775546e+00</second>
+						<second>1.79453497449767663e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56678832510078925e+00</score>
+				<score>1.61907871990206176e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -42431,31 +42431,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.71549469954291367e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>1.05619645677710636e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>8.85440094358336593e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>4.63520193955426318e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>4.02285602588438040e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>2.31788444825865830e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.23907348505551895e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42463,34 +42463,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50547644474688269e+00</second>
+						<second>-1.52764773290690981e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.36040674243553836e-02</second>
+						<second>-7.74577151155540766e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.76659388612201762e-01</second>
+						<second>6.74847677019812853e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.13671501457785706e-01</second>
+						<second>5.20200560440568616e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.05243231709268081e-01</second>
+						<second>5.48782003904771276e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91956745393007512e-02</second>
+						<second>-5.92627984163154008e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.55397390560515580e-01</second>
+						<second>7.55290941523085180e-01</second>
 					</item>
 				</goal_state>
-				<score>1.46775113369699239e+00</score>
+				<score>9.23380828497690487e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42521,31 +42521,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.55905707948953820e+00</second>
+						<second>-1.82265889361364564e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>9.90551972627059796e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.66626876561165815e-01</second>
+						<second>1.08866277262054822e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.79161999085778900e+00</second>
+						<second>4.17553422826939524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.69447138737248126e+00</second>
+						<second>3.68495765019370924e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06831516715105490e+00</second>
+						<second>2.64853904566836107e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.54790739581616799e-01</second>
+						<second>1.54895357967812664e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42553,34 +42553,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74298356744245009e+00</second>
+						<second>-1.69077391746664718e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-6.86670762237855670e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.06206470043442125e-01</second>
+						<second>9.20523713720079351e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84705709009621799e+00</second>
+						<second>4.93744253231816088e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78494963219267921e+00</second>
+						<second>5.01826141251839442e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08647807770610738e+00</second>
+						<second>7.09763288072463860e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18002683311874246e+00</second>
+						<second>1.18061999661530992e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40061118769434723e+00</score>
+				<score>1.50385476329497642e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42611,31 +42611,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42643,34 +42643,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72273755878273893e+00</second>
+						<second>-1.81316281817526970e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.67957594580419971e-02</second>
+						<second>-1.04608144451553017e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13165598875387197e+00</second>
+						<second>1.12464992811060083e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.15694880722176041e-01</second>
+						<second>4.12301344711386353e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.81843870341059000e-01</second>
+						<second>4.08271631503916710e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.19382599520391436e-01</second>
+						<second>5.65016301222691086e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49773831735923957e+00</second>
+						<second>1.49757474101399657e+00</second>
 					</item>
 				</goal_state>
-				<score>2.66831794064073735e+00</score>
+				<score>1.69623436931511523e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42701,31 +42701,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42733,34 +42733,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.85781766370821133e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-1.07131715297995644e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.32566981991872268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>4.31938698370768426e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>3.97073461901793545e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>7.30355269159888298e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.74777852601277739e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55648081361388524e+00</score>
+				<score>1.62515541638795391e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42791,31 +42791,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.91979976374449990e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>6.62163712400231919e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.42689298328804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>2.98122048258170846e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>2.72912572770935113e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>2.12620028654118859e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.95498104608924028e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42823,34 +42823,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76872490052123710e+00</second>
+						<second>-1.87148987909715192e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.25957736005298118e-02</second>
+						<second>-8.69824320758170594e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44629760263244767e+00</second>
+						<second>1.44317901522742087e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92944299624998505e-01</second>
+						<second>4.24836215426251329e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.57318024282256630e-01</second>
+						<second>3.75792571292432487e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84525772214657191e-01</second>
+						<second>9.51608047204321739e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.88873698038749560e+00</second>
+						<second>1.88877289313151064e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34946708802678073e+00</score>
+				<score>1.49193321060227091e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -42971,31 +42971,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.74721028249958343e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>2.61824087602102296e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>8.49735104523453688e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>3.58107231763900857e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>2.25789200174126153e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>3.30295405650624319e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.24437893804050370e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43003,34 +43003,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54366507048984825e+00</second>
+						<second>-1.57784031083916076e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.56105009648136617e-01</second>
+						<second>8.29935905838286164e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.50071567907060555e-01</second>
+						<second>6.57342279747295533e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.60510964856758997e-01</second>
+						<second>4.11900272785284849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.52449647592566340e-01</second>
+						<second>3.50453375393860678e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.84744376758726347e-01</second>
+						<second>1.19670943549623446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40257492939055717e-01</second>
+						<second>8.39878036607591749e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53134877606870923e+00</score>
+				<score>9.77469060989558797e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43061,31 +43061,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43093,34 +43093,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.78942474286095621e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>-9.81614147771863454e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>8.86382786559397395e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>1.92017260696332875e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>6.25911771940805550e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>-7.13073608316907304e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.23900460993199135e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32822155106749928e+00</score>
+				<score>1.50466340983905156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43151,31 +43151,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.91979999266212542e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>-6.30488681843844323e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.42639204092203564e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>-2.99888091296726444e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>-2.74662470148053561e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>-2.10321886536636804e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>1.95333231411720609e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43183,34 +43183,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61061082601743122e+00</second>
+						<second>-1.89561053025758697e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.04012670950677244e-01</second>
+						<second>-8.34189850823440354e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02455400820469422e+00</second>
+						<second>1.09079782863978525e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34876663796617313e+00</second>
+						<second>4.50271715165264166e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.24976402086773386e-01</second>
+						<second>6.35697240032300492e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.56995033304208675e+00</second>
+						<second>-5.53693380227074927e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.54904078177969162e+00</second>
+						<second>1.54896396005587000e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40994679511995669e+00</score>
+				<score>1.66315448004057675e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43241,31 +43241,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43273,34 +43273,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63492630806558026e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.47010694568592792e-01</second>
+						<second>3.20644493963268759e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.19845204488886914e+00</second>
+						<second>1.29124097542818084e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38575892215449237e+00</second>
+						<second>2.73274142974564371e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.46112089806016510e-01</second>
+						<second>2.45028901028168017e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47732519390094508e+00</second>
+						<second>1.62850021450726967e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80307250678343878e+00</second>
+						<second>1.80277636900271321e+00</second>
 					</item>
 				</goal_state>
-				<score>2.27374709391236385e+00</score>
+				<score>1.55360166945871597e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43331,31 +43331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43363,34 +43363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63628200696457493e+00</second>
+						<second>-1.91979999303321858e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.96427483637602107e-01</second>
+						<second>6.77216429461324210e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31259965161918846e+00</second>
+						<second>1.42638334939898925e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42814817976495068e+00</second>
+						<second>2.99961868638436491e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.58158049187980576e-01</second>
+						<second>2.74841333305086255e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.41871189143841070e+00</second>
+						<second>2.15210678445649811e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95503504694060437e+00</second>
+						<second>1.95464598730574157e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05942824131045654e+00</score>
+				<score>1.39514017611240076e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -43511,31 +43511,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43038186785274624e+00</second>
+						<second>-1.76693626184754216e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70461545050305113e-01</second>
+						<second>2.59073833390813135e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63310172185125335e-01</second>
+						<second>8.86321789193149190e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46420374326024794e+00</second>
+						<second>-1.21202026349732331e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38985936870169358e+00</second>
+						<second>-2.33328010901128952e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43749152858263313e-01</second>
+						<second>1.66957517093525326e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.68934538816098456e-01</second>
+						<second>1.18282973177588779e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43543,34 +43543,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54759193472655876e+00</second>
+						<second>-1.61624947912674899e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.45116231934439566e-01</second>
+						<second>8.95628806419516976e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.50684910997385457e-01</second>
+						<second>6.56252711412286249e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59924104937342770e+00</second>
+						<second>-5.98779885674351753e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70078877816619434e+00</second>
+						<second>-1.15129760447289495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.75011120974503220e-01</second>
+						<second>4.46234390821319965e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.38172545163201499e-01</second>
+						<second>8.38239291281499432e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53164067036578322e+00</score>
+				<score>9.83601440545702060e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43601,31 +43601,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.76693626184754216e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>2.59073833390813135e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>8.86321789193149190e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-1.21202026349732331e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-2.33328010901128952e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>1.66957517093525326e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.18282973177588779e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43633,34 +43633,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68508752979002829e+00</second>
+						<second>-1.79050070317942467e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.51052539899245664e-01</second>
+						<second>7.94411482767673899e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.80559462095155010e-01</second>
+						<second>8.91138233824686821e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.58928857195714812e+00</second>
+						<second>-5.47130038596481752e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66862269533115715e+00</second>
+						<second>-8.72708893115359818e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.93348969863758358e-01</second>
+						<second>4.42372413937964643e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24452194545073591e+00</second>
+						<second>1.24406467509465113e+00</second>
 					</item>
 				</goal_state>
-				<score>2.33383769225944615e+00</score>
+				<score>1.51106125095703120e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43691,31 +43691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67625567210292359e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61960506364601520e-01</second>
+						<second>2.27651665749751125e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.78083761912612393e-01</second>
+						<second>1.30212768513526611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56642561142902892e+00</second>
+						<second>-2.48197394159179130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64997149645367847e+00</second>
+						<second>-2.37106221436600761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07293225787140800e-01</second>
+						<second>1.11407491644512760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24415705776787799e+00</second>
+						<second>1.74971646012369497e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43723,34 +43723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75687257357049575e+00</second>
+						<second>-1.88778876760432190e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.74018203165185459e-01</second>
+						<second>4.57656304846310036e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07026347532716670e+00</second>
+						<second>1.09153301701095362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57636530400940744e+00</second>
+						<second>-1.30963118920434829e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64059533251779133e+00</second>
+						<second>-1.32773318777351990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.84840448906571209e-01</second>
+						<second>-1.64539777210562302e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.54399232674553488e+00</second>
+						<second>1.54408793513391629e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41662736443792037e+00</score>
+				<score>1.66394210944927262e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43781,31 +43781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73293397164146890e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35223478337063741e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20206826817653245e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52279141459599954e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.22476014791152554e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27285003863470259e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95350150191251570e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43813,34 +43813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71783948494171534e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.89521102709657874e-01</second>
+						<second>-2.60787998308611157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09156861825053464e+00</second>
+						<second>1.28944902899844838e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47754319115523103e+00</second>
+						<second>-2.72108607592937646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.03469977063958218e-01</second>
+						<second>-2.44427527468376232e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33418826283487224e+00</second>
+						<second>-1.56244456315562913e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79943082955497746e+00</second>
+						<second>1.79914746700753536e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19338564335753849e+00</score>
+				<score>1.55738442176841796e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43871,31 +43871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43903,34 +43903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73293397164146890e+00</second>
+						<second>-1.91979999266212542e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35223478337063741e-01</second>
+						<second>-6.30488681843844323e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20206826817653245e+00</second>
+						<second>1.42639204092203564e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52279141459599954e+00</second>
+						<second>-2.99888091296726444e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.22476014791152554e-01</second>
+						<second>-2.74662470148053561e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27285003863470259e+00</second>
+						<second>-2.10321886536636804e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95350150191251570e+00</second>
+						<second>1.95333231411720609e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00169792413183156e+00</score>
+				<score>1.39724770843998675e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -44051,31 +44051,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59628447741179569e+00</second>
+						<second>-1.67277147061326770e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39068567414967675e-01</second>
+						<second>2.87088769107197661e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.46831405422174144e-01</second>
+						<second>9.20043856513667602e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47733149161698218e+00</second>
+						<second>-4.28778311307386362e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45015025670143860e+00</second>
+						<second>-5.38544120332432708e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.30831401400581684e-02</second>
+						<second>1.48724921785442027e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06023489016656391e+00</second>
+						<second>1.06014758156814559e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44083,34 +44083,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50262674496885218e+00</second>
+						<second>-1.55183076881087967e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.03568203337142553e-02</second>
+						<second>1.58884615898757964e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.68391749412691860e-01</second>
+						<second>6.60312352494525134e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53357787332133677e+00</second>
+						<second>-3.64416009564572707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54389155547212775e+00</second>
+						<second>-4.51921891817979815e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.03328382151066001e-02</second>
+						<second>6.26003269072289981e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.46004140820640371e-01</second>
+						<second>7.46055285322695605e-01</second>
 					</item>
 				</goal_state>
-				<score>1.43871664100513241e+00</score>
+				<score>9.03476470482961064e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44141,31 +44141,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43038186785274624e+00</second>
+						<second>-1.77250629071504462e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70461545050305113e-01</second>
+						<second>2.78220592182186699e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63310172185125335e-01</second>
+						<second>1.13488007508496436e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46420374326024794e+00</second>
+						<second>-4.48393381302409577e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38985936870169358e+00</second>
+						<second>-4.88981450275386031e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43749152858263313e-01</second>
+						<second>1.22882933542945855e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.68934538816098456e-01</second>
+						<second>1.38458194454798655e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44173,34 +44173,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65769986670666714e+00</second>
+						<second>-1.72848159943081892e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.57079176835463567e-02</second>
+						<second>1.36712579105018300e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23389576094452158e-01</second>
+						<second>9.13395159058949302e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55436218608508314e+00</second>
+						<second>-3.62957045117474564e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57043411977661052e+00</second>
+						<second>-4.04609871545653921e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.29549508611307623e-01</second>
+						<second>8.71762835796710024e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18279752174379582e+00</second>
+						<second>1.18297457465656586e+00</second>
 					</item>
 				</goal_state>
-				<score>2.38863337935789533e+00</score>
+				<score>1.50862724838174506e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44231,31 +44231,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.91979137982766113e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>1.76082784252450691e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.42986822081706721e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-3.04833916940697669e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-2.59937724603925169e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>3.83473209219143338e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.89045800957812560e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44263,34 +44263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73996181694739382e+00</second>
+						<second>-1.84487490117467257e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41229827306441139e-02</second>
+						<second>1.78550692294529773e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12838484187793964e+00</second>
+						<second>1.10791005934596498e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56236271816107708e+00</second>
+						<second>-2.93416909422506422e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.59042257284734845e+00</second>
+						<second>-3.16817205371405286e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.80263047342040933e-01</second>
+						<second>4.91732352051192714e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48699258630051001e+00</second>
+						<second>1.48699517248238755e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68234302358124976e+00</score>
+				<score>1.70006870947602168e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44321,31 +44321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44353,34 +44353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>2.27651665749751125e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.30212768513526611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-2.48197394159179130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-2.37106221436600761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.11407491644512760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.74971646012369497e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55544347897950264e+00</score>
+				<score>1.63087470460675066e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44411,31 +44411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.85757080691041576e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>3.01139359957297126e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.73298396012540179e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-3.28063764289420801e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-1.86621892662908684e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.71195568871671339e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>2.12635050095955291e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44443,34 +44443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91979137982766113e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>1.76082784252450691e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.42986822081706721e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-3.04833916940697669e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.59937724603925169e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>3.83473209219143338e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.89045800957812560e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34645678975905270e+00</score>
+				<score>1.49752574253823989e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -44591,31 +44591,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51577355839081807e+00</second>
+						<second>-1.58268650926771004e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50897663084031830e-01</second>
+						<second>4.18716925430245523e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.38651057717524329e-01</second>
+						<second>9.06095671251600843e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40809050581509965e+00</second>
+						<second>-5.04416919679486431e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33597080905572207e+00</second>
+						<second>-6.88766494496957593e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04779696338638018e-01</second>
+						<second>2.98741784083797923e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56760061510644544e-01</second>
+						<second>8.56610471871968593e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44623,34 +44623,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43027994071286857e+00</second>
+						<second>-1.47129316759168649e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.69848289579390105e-01</second>
+						<second>3.33789324513089791e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63440923843041763e-01</second>
+						<second>6.46743797180560298e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46377055921041332e+00</second>
+						<second>-4.41401257842983896e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38966811174495897e+00</second>
+						<second>-6.46764097072881738e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43286369108927059e-01</second>
+						<second>2.09239358896730981e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.69245706922036243e-01</second>
+						<second>5.68918882458883002e-01</second>
 					</item>
 				</goal_state>
-				<score>1.16304709304642206e+00</score>
+				<score>7.19218099425776441e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44681,31 +44681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.68929589545401448e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>3.83073776640201868e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.13723315441991679e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-5.49245621295285313e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-6.28208775160741917e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>2.55847785321566490e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.20695820726903857e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44713,34 +44713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59656142047337113e+00</second>
+						<second>-1.66298031776517696e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39514682833121684e-01</second>
+						<second>2.64898862554590331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.46863856133768556e-01</second>
+						<second>9.25422856477156830e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47853838524477910e+00</second>
+						<second>-4.65152880647415334e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45083227804030779e+00</second>
+						<second>-5.61487872423004131e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.30462161183324805e-02</second>
+						<second>1.28031652205075452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06053724429335827e+00</second>
+						<second>1.06041149324859507e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34654858074884176e+00</score>
+				<score>1.46778319526449930e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44771,31 +44771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44803,34 +44803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68245433046076243e+00</second>
+						<second>-1.76248169994244530e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39685215586301870e-01</second>
+						<second>2.60249460962510504e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16545867677408244e+00</second>
+						<second>1.14000400118979917e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.48729880499814282e+00</second>
+						<second>-4.76221925576770122e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49498154139916206e+00</second>
+						<second>-5.09468960178184660e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.51394799796670412e-02</second>
+						<second>1.02294306894046727e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38459148676464117e+00</second>
+						<second>1.38459430494323388e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78959042552129732e+00</score>
+				<score>1.75189947356637649e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44861,31 +44861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44893,34 +44893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.81753454104301815e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.76063911201914203e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.32445885762265769e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-4.86237709657061090e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-4.67224215403979959e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.06762728293344447e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.62083999908622967e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80047577822184390e+00</score>
+				<score>1.75805546389311840e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44951,31 +44951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65169135203729156e+00</second>
+						<second>-1.80452172515614429e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.34043144742288489e-01</second>
+						<second>4.82846140695784853e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33243071584949258e+00</second>
+						<second>1.50690841335823755e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40410858097137936e+00</second>
+						<second>-5.34508968321917299e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42900590092028512e+00</second>
+						<second>-4.74765561322760432e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.13023032567416651e-01</second>
+						<second>3.42511104532839949e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42475085768363119e+00</second>
+						<second>1.66834689392544777e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44983,34 +44983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75701298430972952e+00</second>
+						<second>-1.89006999257801667e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.54678539074194227e-02</second>
+						<second>2.94157730836888509e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46461720385084382e+00</second>
+						<second>1.41866263657776970e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52031470519337253e+00</second>
+						<second>-3.79169849508065149e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57745974254490706e+00</second>
+						<second>-3.30336905603777209e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09980858886173871e-01</second>
+						<second>1.39917385442913766e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80319073181275225e+00</second>
+						<second>1.80320758024975469e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56019609083287181e+00</score>
+				<score>1.61271443252525265e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -45221,31 +45221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45253,34 +45253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51578471244146229e+00</second>
+						<second>-1.57261069223576810e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50827821335512902e-01</second>
+						<second>3.89822988857325692e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.38648496269702037e-01</second>
+						<second>9.12995558659100204e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40820781547454565e+00</second>
+						<second>-5.44187331746097236e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33598763602412918e+00</second>
+						<second>-7.08442789429210462e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04716453103490154e-01</second>
+						<second>2.81059829675611272e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56825038621876978e-01</second>
+						<second>8.57037225788628731e-01</second>
 					</item>
 				</goal_state>
-				<score>2.10268435612636839e+00</score>
+				<score>1.30782474220832501e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45311,31 +45311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38808302703632291e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.70627840960793653e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.56780033697572607e-01</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31829574679541750e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18728380610188200e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.59652158201288075e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.72958968718864114e-01</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45343,34 +45343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60808923484551203e+00</second>
+						<second>-1.68728489472297372e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43071565420679786e-01</second>
+						<second>3.79593788660866016e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17316384894975800e+00</second>
+						<second>1.13847942044019734e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40748333852928553e+00</second>
+						<second>-5.54551093323347066e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39307381626309734e+00</second>
+						<second>-6.31319444532055574e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.47518176769691700e-01</second>
+						<second>2.52647325908626152e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20701195854197163e+00</second>
+						<second>1.20698540950210820e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80918233002668227e+00</score>
+				<score>1.75665084603850691e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45401,31 +45401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45433,34 +45433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65828330262403600e+00</second>
+						<second>-1.74709019225211137e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43323968110666200e-01</second>
+						<second>3.79442669414986611e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33046097279198072e+00</second>
+						<second>1.29158783438920954e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.41489316333589032e+00</second>
+						<second>-5.61094365391240135e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.43756833024471931e+00</second>
+						<second>-5.79503270101187407e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20414621733159047e-01</second>
+						<second>2.39491480136795082e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42484431312253901e+00</second>
+						<second>1.42471751755554354e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97788731239417803e+00</score>
+				<score>1.86609067966529429e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -45761,31 +45761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.43153606072611095e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.68941400944426467e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>9.57695072155978933e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.85696394313802027e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-9.42672591543108895e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.07341457730388057e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90462717538369508e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45793,34 +45793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38711003965367063e+00</second>
+						<second>-1.42039980609023875e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.66330375210136339e-01</second>
+						<second>5.24638235842740608e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.57217866717956190e-01</second>
+						<second>8.38884520937926759e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31342423122981833e+00</second>
+						<second>-6.43902129888946018e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18590408629651511e+00</second>
+						<second>-9.04570905379904810e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.58627602710992899e-01</second>
+						<second>4.95865662124171158e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73068117441268865e-01</second>
+						<second>4.73041819877758507e-01</second>
 					</item>
 				</goal_state>
-				<score>1.26510833321260363e+00</score>
+				<score>7.88745600244297046e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45851,31 +45851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45883,34 +45883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52413979837612534e+00</second>
+						<second>-1.58919418798779355e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.28152527918693759e-01</second>
+						<second>4.75296395025313900e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12452626419333401e+00</second>
+						<second>1.09104022646427690e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34116611895166127e+00</second>
+						<second>-6.21859335383002088e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.28991850224467264e+00</second>
+						<second>-7.64119456989451828e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.38119975227272440e-01</second>
+						<second>4.13031464823920169e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36118128040124842e-01</second>
+						<second>9.36008798064440151e-01</second>
 					</item>
 				</goal_state>
-				<score>2.52323493338123273e+00</score>
+				<score>1.57431685833704010e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45941,31 +45941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.74693297531941849e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>3.79103265655176713e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.29168148797388782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-5.61344665600463699e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-5.79750985280498843e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>2.39225589632100166e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.42475835253436012e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45973,34 +45973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59810989599078579e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96473804212760261e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28282700582325404e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36326996285087398e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35904914937748966e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45176015426882166e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22484571923982077e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96501439914651321e+00</score>
+				<score>1.85810143197055383e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -46391,31 +46391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -46423,34 +46423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.43153606072611095e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.68941400944426467e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>9.57695072155978933e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.85696394313802027e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-9.42672591543108895e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.07341457730388057e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90462717538369508e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45552548363033196e+00</score>
+				<score>9.10045980477880850e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -48915,31 +48915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81285670128973808e+00</second>
+						<second>-1.73614864946839376e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12697259168847008e+00</second>
+						<second>-8.20176994597105691e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62395732420834604e+00</second>
+						<second>1.54209389627609017e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43986013177225614e+00</second>
+						<second>7.07112755518713776e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57072429698229943e+00</second>
+						<second>6.47707868515154161e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.09576922517238629e+00</second>
+						<second>-8.39582711749457533e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20888429590384461e+00</second>
+						<second>1.19614457957112474e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -48947,34 +48947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.50552021305558448e+00</second>
+						<second>-1.48433856243892248e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17176095839038741e+00</second>
+						<second>-8.51190580411147035e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39162742489165248e+00</second>
+						<second>1.41456454911041574e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52576123288789756e+00</second>
+						<second>7.34234497056036384e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24878824032758207e+00</second>
+						<second>9.10890036051229979e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96807764466960822e+00</second>
+						<second>-1.14703379410529682e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.09141426093715488e-01</second>
+						<second>5.09104935949697857e-01</second>
 					</item>
 				</goal_state>
-				<score>1.76394054728272964e+00</score>
+				<score>1.20524746700962540e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49005,31 +49005,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80543311468609735e+00</second>
+						<second>1.52189635862126349e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.05394518815942773e+00</second>
+						<second>-1.07745970039060657e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75272151513511765e+00</second>
+						<second>-1.36912713306532230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38947657219905762e+00</second>
+						<second>5.08167938023236343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66399234032112409e+00</second>
+						<second>-2.26273290794743298e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00827696029826619e+00</second>
+						<second>1.94205639971016164e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32182745107173005e+00</second>
+						<second>-5.09124781806770788e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49037,34 +49037,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.60219261547086367e+00</second>
+						<second>1.62713668129833611e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12487576024713887e+00</second>
+						<second>-1.11514688764074599e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55274491891846478e+00</second>
+						<second>-1.51981647150181054e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48808338672783913e+00</second>
+						<second>5.55102380641776194e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38780958090104489e+00</second>
+						<second>-2.40598828181687407e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.93296113411537474e+00</second>
+						<second>1.89686303917683152e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.88411049228595506e-01</second>
+						<second>-7.88479425096916597e-01</second>
 					</item>
 				</goal_state>
-				<score>2.58505411645056826e+00</score>
+				<score>1.73986190501743104e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49095,31 +49095,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>-1.91978124277972695e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-1.44028917404360768e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.65639179561152927e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>4.85731972267398504e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>2.98584303745697499e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-1.38850936076816778e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>1.46458924817000047e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49127,34 +49127,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70180119824979714e+00</second>
+						<second>-1.66835777875007940e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61208933347308236e+00</second>
+						<second>-1.37772098056839010e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46789399067866877e+00</second>
+						<second>1.56493116144238797e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.78573417810699631e-01</second>
+						<second>4.18215664512215146e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.38729469789955151e-01</second>
+						<second>6.46012604051891204e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.55641411698714749e+00</second>
+						<second>-1.44689368232210080e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58804363550193961e-01</second>
+						<second>8.59037506907955994e-01</second>
 					</item>
 				</goal_state>
-				<score>2.86537122691224111e+00</score>
+				<score>1.84907109354319726e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49185,31 +49185,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>1.91281588332961716e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>7.02230221332650673e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.31599303818671465e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>-4.11429043995745369e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>6.44974469744472256e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-2.72130534504070187e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>-1.02751682132203537e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49217,34 +49217,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73460503512780018e+00</second>
+						<second>1.71628139966407911e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28448050793543178e+00</second>
+						<second>6.59326022705622017e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47679066904701273e+00</second>
+						<second>1.43913751056738404e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.90867035649140537e-01</second>
+						<second>-3.90972277568185922e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.74561620978228560e-01</second>
+						<second>8.14593931121623704e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.52996780009756805e-01</second>
+						<second>-2.55007951123306187e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.00617945325530367e-01</second>
+						<second>-6.00562186729888814e-01</second>
 					</item>
 				</goal_state>
-				<score>2.05977624675478443e+00</score>
+				<score>1.45175153265105356e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49275,31 +49275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>-1.69051715466143171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>-9.03195442560983608e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>1.54674260911741435e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>8.24754021406128524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>7.84285961226378614e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>-1.14236218668119327e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>7.81734451617662085e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49307,34 +49307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83360884213563291e+00</second>
+						<second>-1.83620111133266994e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92958175926217423e+00</second>
+						<second>-1.22098171794272581e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56922605030601625e+00</second>
+						<second>1.56539642478494745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54053993085076923e+00</second>
+						<second>5.91252440391366707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50630410683652505e+00</second>
+						<second>6.33648585133136044e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.17175106818797792e+00</second>
+						<second>9.66412549836100254e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42909495308566714e-01</second>
+						<second>9.43348377257737347e-01</second>
 					</item>
 				</goal_state>
-				<score>2.73833264850141678e+00</score>
+				<score>1.94125949031943551e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49365,31 +49365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.64824162395894369e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-1.28435015350388437e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.60241270551817983e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>5.11533692956191888e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>6.55380854213489905e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-1.40670776941690279e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>8.58792042577324000e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49397,34 +49397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88566865222674851e+00</second>
+						<second>-1.91979972302529900e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.37577388121325095e+00</second>
+						<second>-1.49986397170232455e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.61480352082282730e+00</second>
+						<second>1.54984785900667066e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.32038987290790799e-01</second>
+						<second>3.90654677493629310e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.31608048721753712e-01</second>
+						<second>5.23059703238867746e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.48037229724794317e-01</second>
+						<second>8.75283702794357299e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06263268088547380e+00</second>
+						<second>1.06241867823402258e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97853579320359563e+00</score>
+				<score>2.04368636542950732e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49455,31 +49455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>1.70896087777688277e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>6.03258611542462297e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>1.43003070551701827e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>-4.46893823630272524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>8.27159422189506000e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>-2.56669196792404053e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>-6.00568522518465042e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49487,34 +49487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>1.91281588332961716e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.40538538113626199e+00</second>
+						<second>7.02230221332650673e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.32628472886373538e+00</second>
+						<second>1.31599303818671465e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.75872425370206986e-01</second>
+						<second>-4.11429043995745369e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32702448192824285e-01</second>
+						<second>6.44974469744472256e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.38228833737893286e-01</second>
+						<second>-2.72130534504070187e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.02767833755982729e+00</second>
+						<second>-1.02751682132203537e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88357235575551707e+00</score>
+				<score>2.02621306260822226e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49545,31 +49545,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>-1.70528585540035094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>2.83375026030477706e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.36880938887057968e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>-1.23020358553835329e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>9.76405017172991108e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>-9.67189723867948464e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>1.11776257378491595e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49577,34 +49577,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73845365113803330e+00</second>
+						<second>-1.69785006482548129e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90633937476718662e+00</second>
+						<second>2.78833070623232837e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51213740750317660e+00</second>
+						<second>1.52331833325962895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.03803551979915598e+00</second>
+						<second>-1.21971693600601294e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.20958329212663074e+00</second>
+						<second>9.68401904247479295e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20861037790856335e-01</second>
+						<second>2.03170812881417584e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.89434430445925783e-01</second>
+						<second>6.89270222663751930e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34282407268101167e+00</score>
+				<score>1.59365259373128870e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49635,31 +49635,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91730574990523683e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.50462831364288574e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.65379047502475074e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>4.20459203675204507e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>1.21817202536410124e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.41356968676956396e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.70858982028020234e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49667,34 +49667,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77197846047015695e+00</second>
+						<second>-1.91979779844678844e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.98618328749709638e+00</second>
+						<second>-1.44028785028574768e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86111341630326832e+00</second>
+						<second>1.65641255412363675e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.35719930029162228e+00</second>
+						<second>4.85812763491726141e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78484133738746875e+00</second>
+						<second>2.98605277535111124e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96056658700258901e+00</second>
+						<second>-1.38832205192655223e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46472789326928021e+00</second>
+						<second>1.46454300677136717e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15583035082615115e+00</score>
+				<score>2.02994507336835717e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49725,31 +49725,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76432032113259485e+00</second>
+						<second>1.84020580356262520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.87785049076220245e+00</second>
+						<second>3.34998784088533716e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.23704501601275485e-01</second>
+						<second>1.15173571439528866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54266727284059657e-01</second>
+						<second>-7.23444680925793393e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.69774067705066001e-01</second>
+						<second>6.84586667469191501e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.73707676792904664e+00</second>
+						<second>3.14149998474369552e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969489732625302e+00</second>
+						<second>-1.64532103737375168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49757,34 +49757,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73641135044809714e+00</second>
+						<second>1.66683277248082318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.62573358572037679e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01876742803950848e+00</second>
+						<second>1.01106843045238182e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97535129607718418e-01</second>
+						<second>-9.85510265184752599e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750280483348497e-01</second>
+						<second>8.74259553844747517e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12362803879805873e-02</second>
+						<second>3.14149998345254389e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48870294390675073e+00</second>
+						<second>-1.48861237131103641e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203726682918937e+00</score>
+				<score>2.00131522386139515e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49815,31 +49815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.83693070389912227e+00</second>
+						<second>-1.76225808221312374e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82927561456175836e+00</second>
+						<second>2.70968374611173735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46863845655415437e+00</second>
+						<second>1.49551508442191183e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.13583353493909334e+00</second>
+						<second>-1.11997372408082874e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31602270875400817e+00</second>
+						<second>8.94199559489954554e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.50312110900653939e-01</second>
+						<second>-1.92762577805533269e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26240530216323976e+00</second>
+						<second>1.26216419835998694e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49847,34 +49847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77730466495425832e+00</second>
+						<second>-1.70528585540035094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96693061005466019e+00</second>
+						<second>2.83375026030477706e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35301256598507447e+00</second>
+						<second>1.36880938887057968e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02883438955599127e+00</second>
+						<second>-1.23020358553835329e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23154570961572851e+00</second>
+						<second>9.76405017172991108e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.56557792585911321e-02</second>
+						<second>-9.67189723867948464e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11737135502758700e+00</second>
+						<second>1.11776257378491595e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95305310401394205e+00</score>
+				<score>2.07136926222882850e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49905,31 +49905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73643636432677173e+00</second>
+						<second>-1.70528585540035094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>2.83375026030477706e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01878274703353910e+00</second>
+						<second>1.36880938887057968e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97534025482065623e-01</second>
+						<second>-1.23020358553835329e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750756914439298e-01</second>
+						<second>9.76405017172991108e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12586922386320393e-02</second>
+						<second>-9.67189723867948464e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48868350544926020e+00</second>
+						<second>1.11776257378491595e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49937,34 +49937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85990884450483729e+00</second>
+						<second>-1.83675464395625299e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78024657962338528e+00</second>
+						<second>2.72579654447592823e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.63022584083147914e+00</second>
+						<second>1.63814366546396317e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.97783691842723419e+00</second>
+						<second>-1.22027977267847398e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.51339575830519335e-01</second>
+						<second>8.71110577923930984e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14128574723019183e+00</second>
+						<second>-9.35635511505702316e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.94595558628390597e-01</second>
+						<second>7.95106918273171370e-01</second>
 					</item>
 				</goal_state>
-				<score>2.66375859496048450e+00</score>
+				<score>1.69326398750871243e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49995,31 +49995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>-1.90452249319105316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-1.70587212597774163e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>1.50074398609937054e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>2.63818936632843115e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>-2.89383879764505081e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>-1.65285380570850138e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>2.10509473855504359e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50027,34 +50027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76069363412145230e+00</second>
+						<second>-1.91979844420350987e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.88632891581004491e+00</second>
+						<second>-1.75433001576906822e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.22397329219062478e-01</second>
+						<second>1.59662612116490110e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.58825529712683711e-01</second>
+						<second>3.86701456657812914e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75943265251787517e-01</second>
+						<second>-4.95563743097356540e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.74186901960491936e+00</second>
+						<second>-1.65833231978318185e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969490136012603e+00</second>
+						<second>1.83958164240893085e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55182926906895702e+00</score>
+				<score>1.62055500239106837e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50085,31 +50085,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50117,34 +50117,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.90671296418576874e+00</second>
+						<second>1.84020580356262520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.34998784088533716e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16128655495151434e+00</second>
+						<second>1.15173571439528866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.12770901099065957e-01</second>
+						<second>-7.23444680925793393e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.84661409444183433e-01</second>
+						<second>6.84586667469191501e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.82583026095726253e-02</second>
+						<second>3.14149998474369552e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64534115479500231e+00</second>
+						<second>-1.64532103737375168e+00</second>
 					</item>
 				</goal_state>
-				<score>2.89508797070991886e+00</score>
+				<score>1.90417287988765893e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50175,31 +50175,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.91976994880093188e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-1.78254315822278131e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.37173685358774478e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-7.47212702680199792e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>6.33909261637347621e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>2.92843507738597930e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>-1.55297715766164757e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50207,34 +50207,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.91979962287364381e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.66575616197071369e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>1.44791500692623210e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>-8.60793457401591633e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>7.39386819410710716e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.05574073947105163e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>-1.26216267861582931e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24930532361811997e+00</score>
+				<score>2.08379644345559251e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50265,31 +50265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78988494173564594e+00</second>
+						<second>1.81657483706537115e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.54635632822048424e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09599932747134110e+00</second>
+						<second>8.87752036328724792e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42539662353259233e+00</second>
+						<second>-4.01348887891836703e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44191236159047564e+00</second>
+						<second>4.28973934010304037e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88947035033986049e-01</second>
+						<second>-1.04354510614831322e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87544630355926167e+00</second>
+						<second>-2.19640237473512601e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50297,34 +50297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64573888600186180e+00</second>
+						<second>1.71642947086116160e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999969581896e+00</second>
+						<second>-1.72821907729789510e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84637701288958467e-01</second>
+						<second>8.75377254934019411e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42861401861503667e+00</second>
+						<second>-6.50644143109667450e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39151560414778341e+00</second>
+						<second>6.25860820054633615e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.10783255383787838e+00</second>
+						<second>1.21429040645989986e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02189078763496344e+00</second>
+						<second>-2.02195067963045849e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11141672573532224e+00</score>
+				<score>1.32962020737168451e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50355,31 +50355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.84020580356262520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>3.34998784088533716e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>1.15173571439528866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>-7.23444680925793393e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>6.84586667469191501e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.14149998474369552e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>-1.64532103737375168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50387,34 +50387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78988494173564594e+00</second>
+						<second>1.85705017498760627e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-4.32462318266492313e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09599932747134110e+00</second>
+						<second>1.08598489075939231e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42539662353259233e+00</second>
+						<second>-6.31189637641318413e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44191236159047564e+00</second>
+						<second>5.96365530946850186e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88947035033986049e-01</second>
+						<second>3.03947204690670514e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87544630355926167e+00</second>
+						<second>-1.87557872031844841e+00</second>
 					</item>
 				</goal_state>
-				<score>2.50007206205944099e+00</score>
+				<score>1.59268869353129228e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50445,31 +50445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.85705017498760627e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.32462318266492313e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.08598489075939231e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-6.31189637641318413e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>5.96365530946850186e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.03947204690670514e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.87557872031844841e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50477,34 +50477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.91976994880093188e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-1.78254315822278131e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.37173685358774478e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-7.47212702680199792e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>6.33909261637347621e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>2.92843507738597930e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>-1.55297715766164757e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.97969848039412005e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50535,31 +50535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>1.81657483706537115e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>-1.54635632822048424e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>8.87752036328724792e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>-4.01348887891836703e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>4.28973934010304037e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-1.04354510614831322e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>-2.19640237473512601e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50567,34 +50567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83558856032609041e+00</second>
+						<second>1.76828491126321219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13913293456714887e-01</second>
+						<second>-8.34574578531983441e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.75907662307599755e-01</second>
+						<second>8.73947222154009662e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.36837327782971241e-01</second>
+						<second>-5.22923106293617712e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.57913592522296709e-01</second>
+						<second>5.20232449977293676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25839874655268857e-01</second>
+						<second>-6.68306465456099900e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13516441625246101e+00</second>
+						<second>-2.13515890952532450e+00</second>
 					</item>
 				</goal_state>
-				<score>1.81293629473299545e+00</score>
+				<score>1.13834098923831617e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50625,31 +50625,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>1.91976994880093188e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-1.78254315822278131e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>1.37173685358774478e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>-7.47212702680199792e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>6.33909261637347621e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>2.92843507738597930e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>-1.55297715766164757e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50657,34 +50657,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82351156045076945e+00</second>
+						<second>1.91979999481906516e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.13157575006690225e-01</second>
+						<second>-1.07463037096588096e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.10013043441297564e+00</second>
+						<second>1.06800680549078097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.27130085717839902e-01</second>
+						<second>-4.95262774706135722e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32418792253928608e-01</second>
+						<second>4.61703028787756875e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47226508039611881e-01</second>
+						<second>-8.78667912125771361e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02113601224369965e+00</second>
+						<second>-2.02095968689091299e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11572347952623829e+00</score>
+				<score>1.35243741851380772e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50715,31 +50715,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.85705017498760627e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-4.32462318266492313e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>1.08598489075939231e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>-6.31189637641318413e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>5.96365530946850186e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.03947204690670514e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>-1.87557872031844841e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50747,34 +50747,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>1.91968570589767351e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82760673632296777e+00</second>
+						<second>-3.14670730705039037e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660958115094534e+00</second>
+						<second>1.37692840719435039e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44621650391428869e+00</second>
+						<second>-6.95953822267121214e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56649280138700719e+00</second>
+						<second>5.75546591922535322e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51352465606452058e-01</second>
+						<second>2.78933253595988573e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70653508035472745e+00</second>
+						<second>-1.70635347297131523e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85395745580648175e+00</score>
+				<score>1.81705126016852347e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50805,31 +50805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85333067320256317e+00</second>
+						<second>1.91979999481906516e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.30881332162781309e-02</second>
+						<second>-1.07463037096588096e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79566541362986065e-01</second>
+						<second>1.06800680549078097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46687038246712265e-01</second>
+						<second>-4.95262774706135722e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82408828576758486e+00</second>
+						<second>4.61703028787756875e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149990651334399e+00</second>
+						<second>-8.78667912125771361e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19428903574285172e+00</second>
+						<second>-2.02095968689091299e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50837,34 +50837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.67446121618897736e+00</second>
+						<second>1.91973197147330676e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.34899667143905022e+00</second>
+						<second>-3.84155155197380582e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33090137702942313e+00</second>
+						<second>1.11957055382129655e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42477255100238143e+00</second>
+						<second>-4.45840168532610825e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.97949679266965806e-01</second>
+						<second>4.64905302533380305e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-7.50538880634493033e-01</second>
+						<second>-3.73543407207486522e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09694069532142668e+00</second>
+						<second>-2.09704093059796914e+00</second>
 					</item>
 				</goal_state>
-				<score>1.86156811361620877e+00</score>
+				<score>1.21412359974289730e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50895,31 +50895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50927,34 +50927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976366967758727e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60944675272011439e+00</second>
+						<second>2.60993243574549361e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47016038483363554e+00</second>
+						<second>-1.46990424669438391e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40928528208225590e+00</second>
+						<second>2.40937057711447977e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59495987891154334e+00</second>
+						<second>-2.59515267602153665e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.49378241225392028e-01</second>
+						<second>-5.48829906523652711e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75229127949802055e+00</second>
+						<second>-1.75230748926813562e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70078461231943301e+00</score>
+				<score>1.73177595833408443e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50985,31 +50985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>1.83568927460245579e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-3.77668847137699548e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>-9.34913554794419843e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>2.82868702620651780e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-2.70664354894977421e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>-3.08025387285031982e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>2.23354922750770601e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51017,34 +51017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>1.91873069933077312e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-7.14344142421292294e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.27527039457789537e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>2.69460163416413812e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.67059522158401208e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>-7.34528517661742653e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.09819397322135437e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83991615996556024e+00</score>
+				<score>1.20271489131401899e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51075,31 +51075,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83777401805191576e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.29948482025989120e-01</second>
+						<second>3.04162448174498778e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40819001289928947e+00</second>
+						<second>1.37069987918811065e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.06314052816798355e-01</second>
+						<second>-2.45147660413979729e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.71139629763152779e-01</second>
+						<second>-5.72791924639454719e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.70361972591768396e+00</second>
+						<second>3.44771725739662083e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70893215042257629e+00</second>
+						<second>-1.70915297844782654e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51107,34 +51107,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91753940899029285e+00</second>
+						<second>-1.91975130283517026e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.38630076404396640e-01</second>
+						<second>5.35700271500661129e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47465141160044544e+00</second>
+						<second>1.47334170072711013e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.36657193849569625e-01</second>
+						<second>-2.40787636538763739e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.47727285445424372e-01</second>
+						<second>-5.45375570592327441e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58631675793795335e+00</second>
+						<second>5.52846531887489334e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75073345049836537e+00</second>
+						<second>-1.75062592092995373e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70351540240111943e+00</score>
+				<score>1.73310551032694660e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51165,31 +51165,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51197,34 +51197,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>1.89980499453265583e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.11931701554997209e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.38146202175927768e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>2.83032007168870203e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-2.73945251123265932e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>-1.14519669493554277e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>2.14354104910291809e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79709988676116561e+00</score>
+				<score>1.11522445724317062e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51255,31 +51255,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91936760030488562e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.07006899300629543e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-1.32987684736916645e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>2.87841194190391425e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-2.76689122785017361e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-1.07642542074668524e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.14336674960685425e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51287,34 +51287,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83906436319784583e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72982808796894572e-01</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09009218730911694e+00</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06907580079819153e-01</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05064238863279424e-01</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.13657257703061959e-01</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01890526354003752e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</goal_state>
-				<score>2.12032625353634829e+00</score>
+				<score>1.33130169426273509e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51345,31 +51345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969083767138970e+00</second>
+						<second>-1.91841066261925608e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70271793940365235e-01</second>
+						<second>1.75516671992257761e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44591087455370992e+00</second>
+						<second>1.36823522313422563e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.60750613187769242e-01</second>
+						<second>-2.39565429759522797e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40420978546068298e+00</second>
+						<second>-6.34775978279835562e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.37633757738052104e-02</second>
+						<second>2.10322460932288180e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27416158315421790e+00</second>
+						<second>-1.55586307506135824e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51377,34 +51377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91544437884218466e+00</second>
+						<second>-1.91979955953838477e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.12174619358087491e-01</second>
+						<second>3.05062360901646956e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37290611902648529e+00</second>
+						<second>1.37117338049802018e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.97557534291561976e-01</second>
+						<second>-2.45085313870299482e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56264616410358848e+00</second>
+						<second>-5.73310069995181304e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.50995670458185027e-01</second>
+						<second>3.45524921599861368e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70888844528127959e+00</second>
+						<second>-1.70885943649947714e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85412753152060583e+00</score>
+				<score>1.81548496325460634e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51435,31 +51435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57494022683167900e+00</second>
+						<second>1.78091255903302059e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.12253977106517783e-02</second>
+						<second>-2.67729811455601985e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.58206752544709039e-01</second>
+						<second>-1.02531633882814299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.82877438931468106e-01</second>
+						<second>-2.31014528640487082e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42425104320007545e+00</second>
+						<second>2.41453102013269882e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.78332158770567428e+00</second>
+						<second>3.04997388314012507e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91968242144955559e+00</second>
+						<second>1.49969943349716051e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51467,34 +51467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72650238241159726e+00</second>
+						<second>-1.91966369462155062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.33441619978613016e-03</second>
+						<second>-1.28713818397393509e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.83074256664899360e-01</second>
+						<second>1.53795747481161782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.52456667533487300e-01</second>
+						<second>2.76427963760903150e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51825148877141514e+00</second>
+						<second>2.39858418603691503e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.01021619619021275e+00</second>
+						<second>1.76540545814243122e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.01047804456087098e+00</second>
+						<second>-2.01023623802223117e+00</second>
 					</item>
 				</goal_state>
-				<score>2.15027866264153866e+00</score>
+				<score>1.34755252616136800e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51525,31 +51525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.81421632788236775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>-1.36181220582870566e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.44647164537252415e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>2.86095561683118094e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>-2.62446325766020960e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>-1.37372105583749149e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>2.23427595955820646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51557,34 +51557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.87075952114819244e+00</second>
+						<second>-1.91552928540693412e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.67113597856464770e-02</second>
+						<second>-8.39500416559373769e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.08852418379802751e+00</second>
+						<second>1.09088777953649796e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14256405178844167e-01</second>
+						<second>-2.59792326844151367e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56522200803644029e+00</second>
+						<second>-4.97367996226828202e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.32558452246696390e-02</second>
+						<second>1.11946834680914410e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87156701312481544e+00</second>
+						<second>-1.87144381671033266e+00</second>
 					</item>
 				</goal_state>
-				<score>2.51520398685996627e+00</score>
+				<score>1.59814495629323206e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51615,31 +51615,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>-1.77067913034333047e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>2.11149882508357256e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>1.10407270792399248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.40132954987103231e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>-7.28995536429001945e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>2.11440895217382768e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>-1.87143725143120543e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51647,34 +51647,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91975467083432294e+00</second>
+						<second>-1.91841066261925608e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.73144822005593169e-01</second>
+						<second>1.75516671992257761e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36793298637698402e+00</second>
+						<second>1.36823522313422563e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.43654138534047160e-01</second>
+						<second>-2.39565429759522797e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50854039664753925e+00</second>
+						<second>-6.34775978279835562e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.08862746679711636e-01</second>
+						<second>2.10322460932288180e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.55586541986482785e+00</second>
+						<second>-1.55586307506135824e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08511919355499087e+00</score>
+				<score>1.97806495425091516e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51705,31 +51705,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.91966369462155062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.28713818397393509e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>1.53795747481161782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>2.76427963760903150e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>2.39858418603691503e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>1.76540545814243122e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>-2.01023623802223117e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51737,34 +51737,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67756094309292059e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.82614998071476159e-02</second>
+						<second>-1.38760217348961268e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.03509008083386855e-01</second>
+						<second>1.59666266780796362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.51979470162094654e-01</second>
+						<second>2.75431959440804919e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42928436442517137e+00</second>
+						<second>5.14575159710750143e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84175859876266879e+00</second>
+						<second>1.65782920023235292e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84177391663201684e+00</second>
+						<second>-1.84170784703497104e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55960584936492008e+00</score>
+				<score>1.61728458812557124e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51795,31 +51795,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.66951464868607879e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>-4.26537018441166399e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.00647869140077262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.16430007432672245e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.27354636161148704e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>3.13844220845669986e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>1.49964826037106236e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51827,34 +51827,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.83146277867547225e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>-2.67982731837354167e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.14153638120624401e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.41496347964889679e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>2.45188215756816463e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.14147735137665007e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>1.65793820776327006e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88344875480654794e+00</score>
+				<score>1.88969883288244739e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51885,31 +51885,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>-1.91841066261925608e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>1.75516671992257761e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>1.36823522313422563e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.39565429759522797e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>-6.34775978279835562e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>2.10322460932288180e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>-1.55586307506135824e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51917,34 +51917,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969083767138970e+00</second>
+						<second>-1.91979965043045486e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70271793940365235e-01</second>
+						<second>1.70015107000783233e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44591087455370992e+00</second>
+						<second>1.44584427756470668e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.60750613187769242e-01</second>
+						<second>-2.28118052680507732e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40420978546068298e+00</second>
+						<second>-7.37220387794975118e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.37633757738052104e-02</second>
+						<second>9.36204055902705723e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27416158315421790e+00</second>
+						<second>-1.27426417452110918e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25586601630836903e+00</score>
+				<score>2.08380816653146311e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51975,31 +51975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.63448679196792890e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.64978545561884737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>2.72629227694931364e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.20491006717536778e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.41593233428176024e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>-1.71086301873635804e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52007,34 +52007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>-1.91979809420531322e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-1.69310271498824805e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>1.64853185295732341e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.66337880224366330e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>-3.07244501534237380e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>1.39830034101214018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>-1.44908617950964747e+00</second>
 					</item>
 				</goal_state>
-				<score>3.20796298364267729e+00</score>
+				<score>2.04102138494051177e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52065,31 +52065,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60176987721037456e+00</second>
+						<second>1.76333446444974840e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.45731572692133055e-02</second>
+						<second>2.14916708297422515e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36846937573378558e+00</second>
+						<second>-1.53292026900899248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.54855432878719546e-01</second>
+						<second>-2.05846453461092338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18143121899762260e+00</second>
+						<second>2.22200722605283785e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.40819129955978550e-01</second>
+						<second>2.90645385464913764e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33444492832379469e-01</second>
+						<second>6.42325850168180668e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52097,34 +52097,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69842527437781610e+00</second>
+						<second>1.66951464868607879e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.92130704492299453e-02</second>
+						<second>-4.26537018441166399e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.00863692662598292e+00</second>
+						<second>-1.00647869140077262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.42238626169744853e-01</second>
+						<second>-2.16430007432672245e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.30919294546896570e+00</second>
+						<second>2.27354636161148704e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35519750969554569e-02</second>
+						<second>3.13844220845669986e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49960548086532408e+00</second>
+						<second>1.49964826037106236e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203462616953177e+00</score>
+				<score>1.99318686212401036e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52155,31 +52155,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68108994411440271e+00</second>
+						<second>-1.76340300932831817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.60692651893204874e-01</second>
+						<second>2.23918748686015023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13464955382387300e+00</second>
+						<second>1.10598400589517243e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.28696368104397285e-01</second>
+						<second>-2.39358882999928735e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.44684043752972680e-01</second>
+						<second>-7.38946357585954949e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.83940461281481138e+00</second>
+						<second>2.19495764180682479e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87150972942930149e+00</second>
+						<second>-1.87150095554267715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52187,34 +52187,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73842889198682360e+00</second>
+						<second>-1.81561672085701398e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31062264819062030e-01</second>
+						<second>8.37373723048996377e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34738654217196774e+00</second>
+						<second>1.33572140648081672e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.15795904506851954e+00</second>
+						<second>-2.11418714753902082e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.41020427566093720e-01</second>
+						<second>-8.65479892632846082e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.05874294179665052e+00</second>
+						<second>4.19913298071143484e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.13907097944374924e+00</second>
+						<second>-1.13902712801705697e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97732187247696656e+00</score>
+				<score>2.08197229780373888e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52245,31 +52245,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76333446444974840e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.14916708297422515e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.53292026900899248e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.05846453461092338e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.22200722605283785e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.90645385464913764e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>6.42325850168180668e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52277,34 +52277,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90606274159480016e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.64309184688986787e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62590454837323284e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07328628834398510e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32729595104946263e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11787249449471693e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.73090110138695663e-01</second>
 					</item>
 				</goal_state>
-				<score>2.59969201292127350e+00</score>
+				<score>1.65586451354595821e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52335,31 +52335,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78773248346576441e+00</second>
+						<second>-1.68304021847771823e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.77837666166757424e+00</second>
+						<second>7.58706155662025594e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79446502359811144e+00</second>
+						<second>1.74387237442897547e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.78973881227557063e-01</second>
+						<second>-9.44176909666115671e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66580929203518568e+00</second>
+						<second>-6.60358574178019797e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04684989523332916e+00</second>
+						<second>9.16747584239542945e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04573451725265532e+00</second>
+						<second>1.22483474277359083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52367,34 +52367,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.79362345948912272e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>1.13204876654422759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.59772644502839500e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-6.72800604964027937e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-6.53831505002115065e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>-1.01130830892028234e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>9.35106417855317895e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74544013012387067e+00</score>
+				<score>1.93508660268908145e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52425,31 +52425,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>-1.56900284912348531e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-2.24997656599121898e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>1.58962557079674527e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.36670086710274363e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>-7.80342421296069566e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>1.16399572530925388e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>-7.90850537420811683e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52457,34 +52457,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979357504961667e+00</second>
+						<second>-1.91806423471974430e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61502411204366303e+00</second>
+						<second>-1.62274080916228902e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53888903315315773e+00</second>
+						<second>1.54294490509011339e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.58815071711967415e-01</second>
+						<second>2.77417874020430810e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62916678194861175e+00</second>
+						<second>-5.12575802659827162e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.75176059586640576e-01</second>
+						<second>-8.79815624901948756e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08020001710103131e+00</second>
+						<second>-1.08035970810376947e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07019943506727611e+00</score>
+				<score>2.05665157874970833e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52515,31 +52515,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73842889198682360e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31062264819062030e-01</second>
+						<second>-1.38760209889569519e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34738654217196774e+00</second>
+						<second>-1.59666257864280992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.15795904506851954e+00</second>
+						<second>2.75431970198732001e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.41020427566093720e-01</second>
+						<second>-3.09013511167980326e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.05874294179665052e+00</second>
+						<second>-1.48376342534719030e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.13907097944374924e+00</second>
+						<second>1.84170789554129244e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52547,34 +52547,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>-1.91979656631420958e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>2.33740873620461409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>-1.33648955839465211e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>-2.82756500236209618e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>2.53565343994524417e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>-4.81923715152446142e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>-1.04553215887862061e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96382541879388084e+00</score>
+				<score>2.04298490883778078e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52605,31 +52605,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90606274159480016e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.64309184688986787e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62590454837323284e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07328628834398510e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32729595104946263e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11787249449471693e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.73090110138695663e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52637,34 +52637,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.76375954009719971e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>2.13543695470787387e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.53283015702739212e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.05984560518387516e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.22241128186760672e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>2.90622827922214677e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>6.42331773205684797e-01</second>
 					</item>
 				</goal_state>
-				<score>2.16823251488438951e+00</score>
+				<score>1.50678726148945369e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52695,31 +52695,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56462825203793021e+00</second>
+						<second>-1.56900284912348531e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.15610684099707095e+00</second>
+						<second>-2.24997656599121898e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71305861025194162e+00</second>
+						<second>1.58962557079674527e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32983370913493371e+00</second>
+						<second>2.36670086710274363e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42867529052722730e+00</second>
+						<second>-7.80342421296069566e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83677130336604399e+00</second>
+						<second>1.16399572530925388e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43433687284591116e-01</second>
+						<second>-7.90850537420811683e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52727,34 +52727,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.48923496664104738e+00</second>
+						<second>-1.48289285837571394e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.25065311632395559e+00</second>
+						<second>-2.28423111561279590e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41434574949438252e+00</second>
+						<second>1.42070771155515407e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44687790582781695e+00</second>
+						<second>2.41368002416382410e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24143394036810983e+00</second>
+						<second>-9.05629755093666722e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.98500457715291523e+00</second>
+						<second>1.14911217071768412e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.19425780294794914e-01</second>
+						<second>-5.19379405829512475e-01</second>
 					</item>
 				</goal_state>
-				<score>1.80804794091836873e+00</score>
+				<score>1.22672048218155388e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52785,31 +52785,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.78400780729564201e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>-2.18875460002261102e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.65705089195764343e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>2.38295107059576283e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-5.84454693638339129e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.00631128759165955e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>-1.22481374500049611e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52817,34 +52817,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63223108688898666e+00</second>
+						<second>-1.58504261725571371e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01777752284855882e+00</second>
+						<second>-2.19692889099803823e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51494615570768176e+00</second>
+						<second>1.57358606024779135e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.45570727533466138e-01</second>
+						<second>2.41844696297676309e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40847590031933034e+00</second>
+						<second>-7.68158458462230187e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.24525430535861514e+00</second>
+						<second>1.18118858822743200e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90981838959245120e-01</second>
+						<second>-7.90785379811686062e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57147490887186558e+00</score>
+				<score>1.74227131530126561e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52875,31 +52875,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>-1.91497235164708268e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>-1.70464635657659613e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>1.65730142331107966e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>2.64990483148188805e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>-3.08358163054050560e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>1.38872368259695866e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>-1.44912563363703750e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52907,34 +52907,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71314035154437549e+00</second>
+						<second>-1.67102439768032185e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.34636628965096250e+00</second>
+						<second>-1.76493119393766085e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.39934618090105012e+00</second>
+						<second>1.56821301459560813e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>2.71245814688745179e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.55949512670593649e-01</second>
+						<second>-6.53294339070352281e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.64796301150958535e+00</second>
+						<second>1.45330006359923103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.43357426664944620e-01</second>
+						<second>-8.43568703837588307e-01</second>
 					</item>
 				</goal_state>
-				<score>2.79564436174218267e+00</score>
+				<score>1.83059221914707027e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52965,31 +52965,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>-1.91979656631420958e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>2.33740873620461409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>-1.33648955839465211e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>-2.82756500236209618e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>2.53565343994524417e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>-4.81923715152446142e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>-1.04553215887862061e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52997,34 +52997,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73322128858838376e+00</second>
+						<second>-1.73322150657936613e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.56934011802913309e-01</second>
+						<second>2.38465643189445364e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44654564584594425e+00</second>
+						<second>-1.44654608972750176e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84850768186289915e+00</second>
+						<second>-2.84850992083411159e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.82237228692500453e-01</second>
+						<second>2.35935589847991967e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.23607933111390511e-01</second>
+						<second>-6.23608664280539071e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.33026351151945388e-01</second>
+						<second>-6.33026352029928963e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15576692900806233e+00</score>
+				<score>1.51431380137903415e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -54765,31 +54765,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>-1.52487897910884040e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>-4.01375941175032391e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>1.49284659907735562e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>9.92902500499797669e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>8.73441823154696650e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>-5.78995959812761196e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>1.08392551325508224e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -54797,34 +54797,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50527518949420713e+00</second>
+						<second>-1.51220574362720939e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.57686113309499765e-01</second>
+						<second>-4.85697671232361794e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43028405084706534e+00</second>
+						<second>1.42736705847518763e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.22856019152355644e+00</second>
+						<second>1.20032635427922774e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.99573877707567893e-01</second>
+						<second>9.93897263305509204e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09764371279093997e+00</second>
+						<second>-1.10033414724777390e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.70755720247307163e-01</second>
+						<second>4.70569956023715263e-01</second>
 					</item>
 				</goal_state>
-				<score>1.65021444059937239e+00</score>
+				<score>1.13580577019727333e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -54855,31 +54855,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.76720011974764923e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-7.07456109589378990e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.62125655805138202e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>5.72003456821069012e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>4.82957158505567752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-6.21537299305244595e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>1.59159888833949492e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -54887,34 +54887,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.62196630904671402e+00</second>
+						<second>-1.66997587550729931e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43542979652923686e+00</second>
+						<second>-8.40983628103827208e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59983928955559263e+00</second>
+						<second>1.56458537314640367e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.12090343725375918e+00</second>
+						<second>8.87196247648427527e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.30617409020898867e+00</second>
+						<second>7.99371138210060450e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.05162056665249271e+00</second>
+						<second>-1.12413481511675362e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81830307155014115e-01</second>
+						<second>7.81756446568844243e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46515399237530142e+00</score>
+				<score>1.73703753581945231e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -55035,31 +55035,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.37453232547675697e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>-3.60516009999356291e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>9.70473733341461364e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>9.29733342083889136e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>1.01359740820754185e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-5.78427793341514174e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>4.56093481952711266e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55067,34 +55067,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.39066059928544861e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>-3.92421982652553458e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>1.02520081125046536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>9.66589829905125542e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>1.02721300219082412e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-6.58110839394071778e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>4.41354048938991383e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35611262663608856e+00</score>
+				<score>8.70408595629342668e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55125,31 +55125,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.53103810805961871e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>-3.32076528744577160e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>1.13728269219177558e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>7.95896583803538782e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>8.46702823431431550e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-3.38594609215859210e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>9.53268590377908565e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55157,34 +55157,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.54713906694333425e+00</second>
+						<second>-1.51233055325147570e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63398341239725253e+00</second>
+						<second>-4.23831880953837170e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.25716559381732962e+00</second>
+						<second>1.27491461338997270e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.32838380521795507e+00</second>
+						<second>9.03809002655551197e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26719643059508202e+00</second>
+						<second>9.11179809505963889e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53883578068425209e+00</second>
+						<second>-5.72740694860674693e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.56747353068549877e-01</second>
+						<second>8.56917139571128472e-01</second>
 					</item>
 				</goal_state>
-				<score>2.54832879623493280e+00</score>
+				<score>1.64941757764485164e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55215,31 +55215,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.61048532245279996e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>-3.18788766131384571e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>1.27914882694189314e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>7.55563777451912055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>7.67798882128520099e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-2.61380057514810249e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>1.22308020745741364e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55247,34 +55247,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.59973861058203526e+00</second>
+						<second>-1.55454513469579347e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.59812708766042544e+00</second>
+						<second>-4.56017023852566539e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45622386142042370e+00</second>
+						<second>1.47998877775080095e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.28911309463765589e+00</second>
+						<second>9.39659441347161950e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.34011097899251208e+00</second>
+						<second>8.45342543783200062e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.50595263101389909e+00</second>
+						<second>-5.99548155736884580e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08390507285924076e+00</second>
+						<second>1.08382896089802028e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03031092297025806e+00</score>
+				<score>1.96147281332511025e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55305,31 +55305,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.76720011974764923e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-7.07456109589378990e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.62125655805138202e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>5.72003456821069012e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>4.82957158505567752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-6.21537299305244595e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>1.59159888833949492e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55337,34 +55337,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66260166713750435e+00</second>
+						<second>-1.72399654599280283e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.46923518546951071e+00</second>
+						<second>-7.94374279257795246e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60288543480526613e+00</second>
+						<second>1.55349149178936430e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.28744035468030749e+00</second>
+						<second>7.33476010991232830e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42815624750602188e+00</second>
+						<second>6.58640254334099673e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.37686494249028391e+00</second>
+						<second>-8.25534364928139808e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617077588841303e+00</second>
+						<second>1.19616214621620998e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29221602511247102e+00</score>
+				<score>2.07001960829502701e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55395,31 +55395,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76577378666234819e+00</second>
+						<second>-1.91979972302529900e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.99664117009518804e+00</second>
+						<second>-1.49986397170232455e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86796749162818920e+00</second>
+						<second>1.54984785900667066e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34730382106805679e+00</second>
+						<second>3.90654677493629310e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78163388304197534e+00</second>
+						<second>5.23059703238867746e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96675406574584533e+00</second>
+						<second>8.75283702794357299e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46463993745789089e+00</second>
+						<second>1.06241867823402258e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55427,34 +55427,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81285670128973808e+00</second>
+						<second>-1.77810788588588831e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12697259168847008e+00</second>
+						<second>-9.40844432888164661e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62395732420834604e+00</second>
+						<second>1.66061871226750268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43986013177225614e+00</second>
+						<second>7.77267492232324386e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57072429698229943e+00</second>
+						<second>5.95684962228939185e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.09576922517238629e+00</second>
+						<second>-1.00683950385418242e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20888429590384461e+00</second>
+						<second>1.20885123207300893e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15611394441710225e+00</score>
+				<score>2.09137417386373731e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55485,31 +55485,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91978124277972695e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.44028917404360768e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.65639179561152927e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>4.85731972267398504e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>2.98584303745697499e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.38850936076816778e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.46458924817000047e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55517,34 +55517,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80911257615387355e+00</second>
+						<second>-1.91979828909336092e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04714581084618308e+00</second>
+						<second>-1.34207938479745281e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.74866681539752067e+00</second>
+						<second>1.59380623995193860e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39670773105489099e+00</second>
+						<second>4.76933995517179965e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66606869262181734e+00</second>
+						<second>4.18310856458050717e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00421279641524519e+00</second>
+						<second>-1.30178233640553453e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32190138546781766e+00</second>
+						<second>1.32179243291193926e+00</second>
 					</item>
 				</goal_state>
-				<score>3.22891375103269285e+00</score>
+				<score>2.09628432640696666e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55575,31 +55575,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.53103810805961871e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>-3.32076528744577160e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>1.13728269219177558e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>7.95896583803538782e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>8.46702823431431550e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-3.38594609215859210e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>9.53268590377908565e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55607,34 +55607,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.53023385341927831e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>-3.55222116095007812e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>1.20372215643461833e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>8.18738099331395963e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>8.62400445751096978e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-3.94267698569576053e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>9.66507623404197380e-01</second>
 					</item>
 				</goal_state>
-				<score>2.67899184079623343e+00</score>
+				<score>1.68253590190557856e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55665,31 +55665,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64888339505604864e+00</second>
+						<second>-1.62827389672696854e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75682184723469170e+00</second>
+						<second>-2.67098769350333554e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26193275250488424e+00</second>
+						<second>1.16770588221971394e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46315423693026769e+00</second>
+						<second>6.95939954387115645e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42313967424857468e+00</second>
+						<second>7.21251838364953213e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83605072481505216e+00</second>
+						<second>-1.61211154177438587e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22314063803218565e+00</second>
+						<second>1.21428475767838018e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55697,34 +55697,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63782262945032153e+00</second>
+						<second>-1.60219319048123743e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72278408328315136e+00</second>
+						<second>-3.56511782275134970e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33042212143335248e+00</second>
+						<second>1.34744769980022006e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43126075113853934e+00</second>
+						<second>7.78763991275822742e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40176035966014290e+00</second>
+						<second>7.82647743244128336e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77034644711207134e+00</second>
+						<second>-3.32398622860533732e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576432327048979e+00</second>
+						<second>1.22588683700842105e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06098562940447394e+00</score>
+				<score>1.91719573364414586e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55755,31 +55755,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64093076962699436e+00</second>
+						<second>-1.67563283691913600e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50967640588486063e+00</second>
+						<second>-2.67942609909107066e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61759321053386107e+00</second>
+						<second>1.32504622689627172e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.24879611565712656e+00</second>
+						<second>6.98423060701464760e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40898542420573980e+00</second>
+						<second>6.81742804506531574e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.39496454987968033e+00</second>
+						<second>-1.40716928129970525e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617507519897037e+00</second>
+						<second>1.42479203712245051e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55787,34 +55787,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68301357575729349e+00</second>
+						<second>-1.61212169216043311e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.65697582283300804e+00</second>
+						<second>-3.70989933940005623e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51487276603243370e+00</second>
+						<second>1.55196068825022104e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.44852104919066837e+00</second>
+						<second>8.02257691080376256e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.48564476195746176e+00</second>
+						<second>7.36916877866685471e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71820666542824885e+00</second>
+						<second>-3.46723606589966815e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44020025755015957e+00</second>
+						<second>1.44050087447009512e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17033239437755254e+00</score>
+				<score>1.98264706766982796e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55845,31 +55845,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.69051715466143171e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-9.03195442560983608e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.54674260911741435e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>8.24754021406128524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>7.84285961226378614e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-1.14236218668119327e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>7.81734451617662085e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55877,34 +55877,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73028272880656697e+00</second>
+						<second>-1.76720011974764923e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50086010196754316e+00</second>
+						<second>-7.07456109589378990e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65600408123794218e+00</second>
+						<second>1.62125655805138202e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50571527616767620e+00</second>
+						<second>5.72003456821069012e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.61511812276850630e+00</second>
+						<second>4.82957158505567752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.57411688722730059e+00</second>
+						<second>-6.21537299305244595e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59166046173256048e+00</second>
+						<second>1.59159888833949492e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07384131191527743e+00</score>
+				<score>1.92525416345088962e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55935,31 +55935,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>-1.91979972302529900e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-1.49986397170232455e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>1.54984785900667066e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>3.90654677493629310e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>5.23059703238867746e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>8.75283702794357299e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>1.06241867823402258e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55967,34 +55967,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76343536150351610e+00</second>
+						<second>-1.87141702645888364e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.28917221203157073e+00</second>
+						<second>-1.06511635054396003e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76356426267541155e+00</second>
+						<second>1.61089972818356331e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51694194520703185e+00</second>
+						<second>4.10190600706776820e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.74860638873879193e+00</second>
+						<second>2.85344816023842707e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.36622373415104859e+00</second>
+						<second>-9.69924460066896921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67186848616890305e+00</second>
+						<second>1.67202359020126679e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88103207717149568e+00</score>
+				<score>1.85206518896577244e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56025,31 +56025,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>-1.91730574990523683e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.50462831364288574e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>1.65379047502475074e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>4.20459203675204507e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>1.21817202536410124e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>-1.41356968676956396e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>1.70858982028020234e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56057,34 +56057,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78883735977529579e+00</second>
+						<second>-1.91979564422519644e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04325810964676124e+00</second>
+						<second>-1.35118139541940030e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82834116880776176e+00</second>
+						<second>1.61825201456570555e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48493371917429817e+00</second>
+						<second>3.90926337331035156e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86477796978246513e+00</second>
+						<second>2.00338143284161940e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11371386212309620e+00</second>
+						<second>-1.26239806627998763e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060799679946403e+00</second>
+						<second>1.67051817471563613e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79977746227816171e+00</score>
+				<score>1.85422325811238298e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56115,31 +56115,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>-1.91979828909336092e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.34207938479745281e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>1.59380623995193860e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>4.76933995517179965e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>4.18310856458050717e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>-1.30178233640553453e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>1.32179243291193926e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56147,34 +56147,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67761563718845697e+00</second>
+						<second>-1.91730574990523683e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80706038361905952e+00</second>
+						<second>-1.50462831364288574e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.47464609917325751e-01</second>
+						<second>1.65379047502475074e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.04496150312718816e-01</second>
+						<second>4.20459203675204507e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.56230579649813794e-01</second>
+						<second>1.21817202536410124e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53873150157934191e+00</second>
+						<second>-1.41356968676956396e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70872047229901081e+00</second>
+						<second>1.70858982028020234e+00</second>
 					</item>
 				</goal_state>
-				<score>2.69433900641181001e+00</score>
+				<score>1.79848730222440939e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56205,31 +56205,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.70376908905464974e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.79278557007483602e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.15787920958422097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.08230408960001134e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>6.12266801857534237e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-1.66802025071915057e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.37494075727534337e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56237,34 +56237,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.68385600576233219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>-2.94614757241652980e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>1.41567801972034624e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>7.07921337165089537e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>6.71521340818092227e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>-1.73140074322937432e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.50002012354521108e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01336339798945607e+00</score>
+				<score>1.88596403415454167e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56295,31 +56295,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.91979999497711029e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>-2.56011337404089157e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>1.51861559127647583e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>2.95685564725513050e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>2.23956736752649210e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>-1.26744763875257238e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.96544162995486027e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56327,34 +56327,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.81693096738847371e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>-5.03585615104098494e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>1.49692972707963001e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>5.10545334772530501e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>4.55921478778989142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-3.63537356949758639e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.66896022430404867e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88489552071470179e+00</score>
+				<score>1.80672831166203196e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56385,31 +56385,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.76720011974764923e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-7.07456109589378990e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.62125655805138202e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>5.72003456821069012e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>4.82957158505567752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-6.21537299305244595e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>1.59159888833949492e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56417,34 +56417,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76111598476318498e+00</second>
+						<second>-1.82580174832858377e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.61441540644511639e+00</second>
+						<second>-6.37834987306319490e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71610815864412869e+00</second>
+						<second>1.65798338817236757e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.53875593269465671e+00</second>
+						<second>5.01357087021478631e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.70636165031785714e+00</second>
+						<second>3.46474341030831468e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74537194027882459e+00</second>
+						<second>-5.03760355404116345e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82027911721189417e+00</second>
+						<second>1.82027454990380089e+00</second>
 					</item>
 				</goal_state>
-				<score>2.64633262546205428e+00</score>
+				<score>1.65594209606970855e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56475,31 +56475,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.84889058159822972e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.37377523809291513e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.77611424582722033e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>5.66199474331968600e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>1.38082845743625782e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.28015905489702808e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>1.70873054284765424e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56507,34 +56507,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-1.05826657479549024e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.59341907889505263e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>2.70809001247425130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>7.51608928851427022e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-9.66198790434753096e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>1.91441929149645507e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39748128924333859e+00</score>
+				<score>1.51605550532738720e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56565,31 +56565,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>1.85224380142033507e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.59759311887830835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>-1.64146021030937028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>3.80003210626191856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>2.84078825058870565e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>1.65286908910514829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>-2.10516659127283168e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56597,34 +56597,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>1.91979998757461501e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.36293310252658717e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>-1.58707178877744859e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>2.64407191835180744e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>3.10531015129618915e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>1.86108204610146921e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>-1.95015299191684210e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24219973155004393e+00</score>
+				<score>1.45528142982558312e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56655,31 +56655,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>-1.90452249319105316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-1.70587212597774163e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>1.50074398609937054e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>2.63818936632843115e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>-2.89383879764505081e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>-1.65285380570850138e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>2.10509473855504359e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56687,34 +56687,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>-1.91979999812392776e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.60882511743130197e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>1.57910476491579099e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>3.12365956839485759e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>-7.89227743091635708e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>-1.52177846625536262e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>1.92764893022615791e+00</second>
 					</item>
 				</goal_state>
-				<score>2.26602256782084677e+00</score>
+				<score>1.48877010079399463e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56745,31 +56745,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56777,34 +56777,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68429938207733176e+00</second>
+						<second>-1.84386498820978018e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.40222118714297822e-01</second>
+						<second>-3.68430009119411705e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46041720974469524e+00</second>
+						<second>1.39841411032814134e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.19731508275365806e-01</second>
+						<second>4.56042565906396025e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.64864492080486480e-01</second>
+						<second>4.25413213359060516e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.23697265304050408e-02</second>
+						<second>-2.10101312996693573e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68232408561779012e+00</second>
+						<second>1.68230829650060332e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77559167773378457e+00</score>
+				<score>1.74618700548447248e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56835,31 +56835,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69489539870812900e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.06356020858098574e-01</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36316029981210418e+00</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.98822107106659596e-01</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.56335127311222677e-01</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.03488596581905384e-02</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62517132664029740e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56867,34 +56867,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68489224071480215e+00</second>
+						<second>-1.85551324748300162e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10058432653208749e-01</second>
+						<second>-3.55558721938333544e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58508847215998983e+00</second>
+						<second>1.52355909107725229e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.01743863827361425e-01</second>
+						<second>4.57346310388088428e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.34248571507239345e-01</second>
+						<second>3.76300195952152416e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.09359040907673738e-02</second>
+						<second>-1.93144045722935864e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84028735871544136e+00</second>
+						<second>1.84025700268086179e+00</second>
 					</item>
 				</goal_state>
-				<score>2.52598125986216182e+00</score>
+				<score>1.59511132825297997e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56925,31 +56925,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56957,34 +56957,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75057684866669527e+00</second>
+						<second>-1.79325916885093961e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80999024257839425e+00</second>
+						<second>-4.02907240679780010e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77223621402302967e+00</second>
+						<second>1.74694371198029597e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56813052353909521e+00</second>
+						<second>5.19082532696751420e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72788169594534002e+00</second>
+						<second>3.46542608752741177e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96902939281263123e+00</second>
+						<second>-2.44285884602256004e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99579337418176017e+00</second>
+						<second>1.99578731961390177e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21809838483436783e+00</score>
+				<score>1.38846828114499443e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57015,31 +57015,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>1.91979998757461501e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.36293310252658717e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>-1.58707178877744859e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>2.64407191835180744e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>3.10531015129618915e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>1.86108204610146921e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>-1.95015299191684210e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57047,34 +57047,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>1.91582072336386866e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-9.59387918851122179e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>-1.63219018578321018e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>1.89853503483074365e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>3.03926008986235940e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>2.24944830962325604e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>-2.10145625239123612e+00</second>
 					</item>
 				</goal_state>
-				<score>1.91392628560236422e+00</score>
+				<score>1.20179149006335320e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57105,31 +57105,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>1.91979998757461501e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.36293310252658717e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>-1.58707178877744859e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>2.64407191835180744e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>3.10531015129618915e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>1.86108204610146921e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>-1.95015299191684210e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57137,34 +57137,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48044605467996337e+00</second>
+						<second>1.88830776182294358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82452267088588060e+00</second>
+						<second>-1.32470863955837492e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.85931594604054384e-01</second>
+						<second>-1.60880686747140289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.79007998394638990e-01</second>
+						<second>2.21230398332994099e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.06441291034145946e-01</second>
+						<second>2.89456470269480892e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.69776935555886421e+00</second>
+						<second>1.88120643780612662e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14040169315113449e+00</second>
+						<second>-2.14036985188074302e+00</second>
 					</item>
 				</goal_state>
-				<score>1.58325495754528789e+00</score>
+				<score>1.12439537530696534e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57195,31 +57195,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.91730574990523683e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.50462831364288574e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>1.65379047502475074e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>4.20459203675204507e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>1.21817202536410124e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-1.41356968676956396e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>1.70858982028020234e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57227,34 +57227,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54146591030873847e+00</second>
+						<second>-1.90452249319105316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.70587212597774163e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.24629259158364958e-01</second>
+						<second>1.50074398609937054e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44684139822691016e+00</second>
+						<second>2.63818936632843115e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38291662796365422e+00</second>
+						<second>-2.89383879764505081e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04354123181146452e+00</second>
+						<second>-1.65285380570850138e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10510314143936172e+00</second>
+						<second>2.10509473855504359e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82090852553084082e+00</score>
+				<score>1.18473199760104383e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57285,31 +57285,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79212874292503455e+00</second>
+						<second>-1.86651249208392156e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92496606412284860e-01</second>
+						<second>-5.38359650131549627e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71318190447731200e+00</second>
+						<second>1.68274718462800132e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.47722336110688257e-01</second>
+						<second>3.98828853446012765e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.99096021371104892e-01</second>
+						<second>2.19284865330130280e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.42002696284059660e-01</second>
+						<second>-3.97442133324389046e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19783985879488997e+00</second>
+						<second>1.99581991568401351e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57317,34 +57317,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76599754067232761e+00</second>
+						<second>-1.91979999497711029e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.83269047280079970e-03</second>
+						<second>-2.56011337404089157e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55879496176615673e+00</second>
+						<second>1.51861559127647583e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.74622699279143778e-01</second>
+						<second>2.95685564725513050e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.29864572704680570e-01</second>
+						<second>2.23956736752649210e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11735722204406757e-01</second>
+						<second>-1.26744763875257238e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562691171959791e+00</second>
+						<second>1.96544162995486027e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22261760443252054e+00</score>
+				<score>1.41162359947598182e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57375,31 +57375,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67909346591687791e+00</second>
+						<second>-1.88110321539179370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.02944732388987936e-01</second>
+						<second>1.01339412836803588e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58591236199384777e+00</second>
+						<second>1.73047566985697276e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.08245477472714047e-01</second>
+						<second>-1.13606579453618406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.41847013319608806e-01</second>
+						<second>-6.34558061192635747e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.76295787475160537e-02</second>
+						<second>5.13420073155334486e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84018462274060735e+00</second>
+						<second>2.19857982173747502e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57407,34 +57407,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69024088592822186e+00</second>
+						<second>-1.85716434602526603e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.32249675648927047e-02</second>
+						<second>-2.90215846461665428e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77646637156888931e+00</second>
+						<second>1.73196989921850109e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.53281489341155508e-01</second>
+						<second>3.28320959323998518e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.24542689438383780e-01</second>
+						<second>1.90733446894197051e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96793586381210084e-01</second>
+						<second>-1.60138746797095083e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704241004368244e+00</second>
+						<second>2.12704163903230237e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85058777913007111e+00</score>
+				<score>1.16857262180334834e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57465,31 +57465,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74464655436084648e+00</second>
+						<second>-1.91979999497711029e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.58802106428551483e-02</second>
+						<second>-2.56011337404089157e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55839273722332639e+00</second>
+						<second>1.51861559127647583e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00102572895211406e-01</second>
+						<second>2.95685564725513050e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.62897973861232526e-01</second>
+						<second>2.23956736752649210e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.44420032308462487e-01</second>
+						<second>-1.26744763875257238e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96569910964345551e+00</second>
+						<second>1.96544162995486027e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57497,34 +57497,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24628822490843394e+00</second>
+						<second>-1.77746472466113192e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.51153637677357144e-01</second>
+						<second>-5.49730472431458783e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91898034040003695e+00</second>
+						<second>1.91974778982616057e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.02532876186664512e-01</second>
+						<second>2.93465556207009759e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.85962431984410803e-01</second>
+						<second>-2.63766893478918456e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70931425880790488e-01</second>
+						<second>-4.30546504523706741e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24541234239523213e+00</second>
+						<second>2.24537709928287743e+00</second>
 					</item>
 				</goal_state>
-				<score>1.41428471295579272e+00</score>
+				<score>9.52514591012471462e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -57645,31 +57645,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.90452249319105316e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.70587212597774163e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>1.50074398609937054e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>2.63818936632843115e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>-2.89383879764505081e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-1.65285380570850138e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>2.10509473855504359e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57677,34 +57677,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78755704503224244e+00</second>
+						<second>-1.79437048762006901e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40983277476643387e+00</second>
+						<second>-1.74523623370205305e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.51296694592313496e+00</second>
+						<second>1.49406737259769185e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.23169848335719712e-01</second>
+						<second>3.11410540294277616e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.34067548553156191e-01</second>
+						<second>-5.30946139056462041e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.45057298933861367e+00</second>
+						<second>-1.71226667931004162e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23616801111425101e+00</second>
+						<second>2.23623712763968996e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49453310398337824e+00</score>
+				<score>9.44839222341094104e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57735,31 +57735,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>1.91979999481906516e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>-1.07463037096588096e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>1.06800680549078097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>-4.95262774706135722e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>4.61703028787756875e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-8.78667912125771361e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>-2.02095968689091299e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57767,34 +57767,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.86820585335608591e+00</second>
+						<second>1.81657483706537115e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.99559885120543828e-02</second>
+						<second>-1.54635632822048424e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.80435939785043531e-01</second>
+						<second>8.87752036328724792e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.13334507195038359e-01</second>
+						<second>-4.01348887891836703e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65619416706035782e-01</second>
+						<second>4.28973934010304037e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.89096095470976289e-02</second>
+						<second>-1.04354510614831322e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19641069277522227e+00</second>
+						<second>-2.19640237473512601e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64920974695174438e+00</score>
+				<score>1.03164425209879035e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57825,31 +57825,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63835038081536477e+00</second>
+						<second>-1.88518310379963117e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.44617791790042649e-01</second>
+						<second>-1.23383258221130152e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.19973239526807918e+00</second>
+						<second>1.72571374968422542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38904506351376877e+00</second>
+						<second>9.10096038444672961e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.41979538194622701e-01</second>
+						<second>3.54857613031446320e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.48089472495571561e+00</second>
+						<second>-8.37105441110127663e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80299758989660330e+00</second>
+						<second>2.19777689152488476e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57857,34 +57857,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.62697928077193388e+00</second>
+						<second>-1.91965722768746549e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.22808554036886108e-01</second>
+						<second>2.57114732467630322e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41291226084057575e+00</second>
+						<second>1.53760456490336184e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47445485038121227e+00</second>
+						<second>2.48664532435539015e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.62866209903653281e-01</second>
+						<second>2.26692443997850851e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.40932882685638994e+00</second>
+						<second>1.46694935125216558e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05334338872552280e+00</second>
+						<second>2.05317525444981053e+00</second>
 					</item>
 				</goal_state>
-				<score>1.88598838543338632e+00</score>
+				<score>1.26990832319017255e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57915,31 +57915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69024088592822186e+00</second>
+						<second>-1.88110321539179370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.32249675648927047e-02</second>
+						<second>1.01339412836803588e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77646637156888931e+00</second>
+						<second>1.73047566985697276e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.53281489341155508e-01</second>
+						<second>-1.13606579453618406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.24542689438383780e-01</second>
+						<second>-6.34558061192635747e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96793586381210084e-01</second>
+						<second>5.13420073155334486e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704241004368244e+00</second>
+						<second>2.19857982173747502e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57947,34 +57947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79212874292503455e+00</second>
+						<second>-1.88199355591039508e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92496606412284860e-01</second>
+						<second>-9.98606678982085355e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71318190447731200e+00</second>
+						<second>1.72872329837300298e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.47722336110688257e-01</second>
+						<second>1.11832330973642119e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.99096021371104892e-01</second>
+						<second>6.26910599270757013e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.42002696284059660e-01</second>
+						<second>-5.05362798064035446e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19783985879488997e+00</second>
+						<second>2.19776771007740201e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65058734548291319e+00</score>
+				<score>1.04856721833875344e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -58275,31 +58275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91979999999999995e+00</second>
+						<second>-1.91856842075775336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35506134573384474e-01</second>
+						<second>-3.08712862530746701e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47321701443612763e+00</second>
+						<second>9.10971036806496159e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33548484254081479e-01</second>
+						<second>-2.95712469166303782e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.45261440489975158e-01</second>
+						<second>-4.83967540478665512e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58899827189118925e+00</second>
+						<second>2.89009279576365641e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75067389718719335e+00</second>
+						<second>-2.19433807291058125e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58307,34 +58307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>-1.91354526929908841e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>-2.96699999823420724e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>-8.96393047011330713e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>3.10055032447312451e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>3.10864217347555627e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-3.00111229863312090e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>-2.23354773169291532e+00</second>
 					</item>
 				</goal_state>
-				<score>1.54547722847656099e+00</score>
+				<score>9.64922798384794528e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58365,31 +58365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64397562085141113e+00</second>
+						<second>-1.88110321539179370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.90431335606353291e-01</second>
+						<second>1.01339412836803588e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31609272618829398e+00</second>
+						<second>1.73047566985697276e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43425117612246478e+00</second>
+						<second>-1.13606579453618406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.48905466185118773e-01</second>
+						<second>-6.34558061192635747e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.42760024651516648e+00</second>
+						<second>5.13420073155334486e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95478867818194790e+00</second>
+						<second>2.19857982173747502e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58397,34 +58397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74567849187351976e+00</second>
+						<second>-1.91974982724778664e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.84281029513646466e-01</second>
+						<second>-2.49636082753490196e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.28120528764413688e+00</second>
+						<second>1.53636916111977317e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58556877000494989e+00</second>
+						<second>-2.49754419076991308e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.17162730336124565e-01</second>
+						<second>-2.27578634645901001e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.23496900922681307e+00</second>
+						<second>-1.46451361332872815e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05212877389038173e+00</second>
+						<second>2.05181796804684247e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83670500010024140e+00</score>
+				<score>1.27188510155362255e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58455,31 +58455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.85787236911507070e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>-2.92112312886661452e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.73140239930820061e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>3.26501094606901521e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>1.88612769789108486e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>-1.62395844981933268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>2.12710266818904392e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58487,34 +58487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80051413989667086e+00</second>
+						<second>-1.88110321539179370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.69834842842290779e-01</second>
+						<second>1.01339412836803588e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71986812406393019e+00</second>
+						<second>1.73047566985697276e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.80890980838127424e+00</second>
+						<second>-1.13606579453618406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76665283496820047e+00</second>
+						<second>-6.34558061192635747e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.12561780301085057e-01</second>
+						<second>5.13420073155334486e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19863857075665026e+00</second>
+						<second>2.19857982173747502e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65103478786181457e+00</score>
+				<score>1.04721980077719670e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -58815,31 +58815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.90834388427793722e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.44554887586563213e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>8.99056012142462113e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.92222233699381784e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.01668314498864210e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.94297015775614490e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.19434565547076810e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58847,34 +58847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>-1.91184412305463924e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.45547814811618631e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>8.91835363084808264e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-3.07582741504057156e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>6.57697155453398148e-04</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>3.02567735928825243e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>-2.23335571018392498e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.65870686626314340e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58905,31 +58905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.88268840801550197e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>3.40439123886749961e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.66837551150107855e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>1.03912936643083029e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>2.13628065931490030e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>3.97112986077753638e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>2.19858366183026543e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58937,34 +58937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77244534066039638e+00</second>
+						<second>-1.91943590458013325e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.58479539953735281e-02</second>
+						<second>2.62988106306290825e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56574747803144088e+00</second>
+						<second>1.52385994771427113e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57658112755899982e+00</second>
+						<second>-2.95359144956567343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62471222628069967e+00</second>
+						<second>-2.21234487708968752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.94390372407894779e-01</second>
+						<second>1.34505221995282115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.96945581260698921e+00</second>
+						<second>1.96929460238571985e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21826632113994204e+00</score>
+				<score>1.40687276939516853e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58995,31 +58995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.86276796520798915e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>3.69856741868815453e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.51684807570517100e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-4.42469711861834869e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-3.62933975797751662e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.10460781383860929e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.83808528308782404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59027,34 +59027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74504398299751173e+00</second>
+						<second>-1.84856317616117716e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.63440811853462464e-02</second>
+						<second>2.79656116123269849e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77799598937385639e+00</second>
+						<second>1.73968860392283120e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.64396110239016524e+00</second>
+						<second>-3.46397639302260252e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.71626210839407634e+00</second>
+						<second>-2.09566620515176216e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-9.09535897830051204e-02</second>
+						<second>1.44402525475266386e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12630334574486701e+00</second>
+						<second>2.12629516717570954e+00</second>
 					</item>
 				</goal_state>
-				<score>1.86142523524178038e+00</score>
+				<score>1.16992265449059357e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59085,31 +59085,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91943590458013325e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.62988106306290825e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.52385994771427113e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.95359144956567343e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.21234487708968752e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.34505221995282115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.96929460238571985e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59117,34 +59117,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.84245461901871166e+00</second>
+						<second>-1.77759110320410807e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04194671261787009e+00</second>
+						<second>5.35665610513498813e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47154084714350342e+00</second>
+						<second>1.91966308495974181e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.02006896370979705e+00</second>
+						<second>-2.91952051186988470e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.58064476397714693e-01</second>
+						<second>2.01010538325842869e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.97512776275998991e+00</second>
+						<second>4.17447339255295147e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598621125695619e+00</second>
+						<second>2.24588370141706095e+00</second>
 					</item>
 				</goal_state>
-				<score>1.46433250340691146e+00</score>
+				<score>9.52508817586518869e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -59265,31 +59265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>1.91959300449863335e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-1.28719460706379230e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.53802395200535602e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>2.76420216320165268e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.90169224967037476e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>-1.37625898048339113e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.01025368267273041e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59297,34 +59297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82360175648419687e+00</second>
+						<second>1.81421632788236775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.80198631524536568e+00</second>
+						<second>-1.36181220582870566e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41685676848750575e+00</second>
+						<second>-1.44647164537252415e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.88031591604325721e+00</second>
+						<second>2.86095561683118094e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.63110363736412101e+00</second>
+						<second>-2.62446325766020960e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.80260502746759488e+00</second>
+						<second>-1.37372105583749149e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23428557187584342e+00</second>
+						<second>2.23427595955820646e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49885286916037175e+00</score>
+				<score>9.48378270324139044e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59355,31 +59355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.91187004356223089e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.46101084765740435e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>8.91898612559418935e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>-3.07644195291917422e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>1.26052528225720044e-03</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>3.02502378112670378e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>-2.23336732679836958e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59387,34 +59387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85333067320256317e+00</second>
+						<second>-1.90834388427793722e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.30881332162781309e-02</second>
+						<second>-2.44554887586563213e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79566541362986065e-01</second>
+						<second>8.99056012142462113e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46687038246712265e-01</second>
+						<second>-2.92222233699381784e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82408828576758486e+00</second>
+						<second>-1.01668314498864210e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149990651334399e+00</second>
+						<second>2.94297015775614490e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19428903574285172e+00</second>
+						<second>-2.19434565547076810e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65744782516677236e+00</score>
+				<score>1.02725588591533357e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59445,31 +59445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.74693297531941849e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>3.79103265655176713e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.29168148797388782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-5.61344665600463699e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-5.79750985280498843e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.39225589632100166e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.42475835253436012e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59477,34 +59477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72504223409326762e+00</second>
+						<second>-1.81461359195026950e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.90157206831705589e-01</second>
+						<second>3.17800180549092259e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45170443676102234e+00</second>
+						<second>1.41710118535430474e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47645469444311583e+00</second>
+						<second>-5.17876464592737396e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53093271950779153e+00</second>
+						<second>-4.76548908017365991e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48004715393510108e-02</second>
+						<second>1.50531357010859790e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68405799119905430e+00</second>
+						<second>1.68401477556083479e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78055596923877602e+00</score>
+				<score>1.74522532108407680e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59535,31 +59535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.88998194318797830e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.94214754404261813e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.41871748906840289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-3.79507397312765171e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-3.30433658424182264e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.39771497916728965e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.80317861525538325e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59567,34 +59567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73925868115602777e+00</second>
+						<second>-1.86269606449140257e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.95930118755284877e+00</second>
+						<second>3.69729125693108340e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57284722306790581e+00</second>
+						<second>1.51690009777137469e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50288142124191326e+00</second>
+						<second>-4.42618490002451348e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58147363065314694e+00</second>
+						<second>-3.63068459554025946e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149999579694716e+00</second>
+						<second>2.10302230079048053e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83804557518041944e+00</second>
+						<second>1.83808529776378071e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53970747685909259e+00</score>
+				<score>1.59772587071872307e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59625,31 +59625,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.75786979074899219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>4.07042851871032174e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.53855160060295226e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-6.15417519729974161e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-5.41172080229784136e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.68948829595595795e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.66833891564881709e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59657,34 +59657,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67377703949013479e+00</second>
+						<second>-1.76798721997376918e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.08611511046432690e-01</second>
+						<second>3.55511645958853706e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.80046709834742580e+00</second>
+						<second>1.76082585031201777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.48788568916233022e+00</second>
+						<second>-5.52008541697727617e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61393424299679067e+00</second>
+						<second>-3.88254975816184567e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.76723117303994046e-02</second>
+						<second>1.95661542546583495e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99619155314470342e+00</second>
+						<second>1.99613689870903954e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21362188995722198e+00</score>
+				<score>1.38794875569116904e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59715,31 +59715,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59747,34 +59747,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75112159522088695e+00</second>
+						<second>-1.90509089002319643e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.96564249582994921e-01</second>
+						<second>9.37905573316270225e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91924127517627552e+00</second>
+						<second>1.66576255842348075e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63434256221412078e+00</second>
+						<second>-2.25842274907401053e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.95756546689315902e+00</second>
+						<second>8.34269476046092667e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.44994647667382559e-01</second>
+						<second>8.54707547956793268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10284521336635377e+00</second>
+						<second>2.10305163386111049e+00</second>
 					</item>
 				</goal_state>
-				<score>1.90730805186448604e+00</score>
+				<score>1.19927116066640041e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59805,31 +59805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.87233465475948413e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.25142140040781569e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.70475989733042899e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.97359943828270257e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-2.16874911276023652e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.15957522395458468e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.68210894418714973e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59837,34 +59837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80902140764373498e+00</second>
+						<second>-1.89361985398684651e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13647809330280403e+00</second>
+						<second>1.33235013192359175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.82257713740364036e+00</second>
+						<second>1.59004357106369354e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.90797684858574079e-01</second>
+						<second>-2.02200477724989364e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.69108102408746075e-01</second>
+						<second>2.50942327465248360e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.91534008625388763e-01</second>
+						<second>1.27747315132098027e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14114766393780620e+00</second>
+						<second>2.14109265945981253e+00</second>
 					</item>
 				</goal_state>
-				<score>1.62385540630320691e+00</score>
+				<score>1.12363485237570684e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59895,31 +59895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67756094309292059e+00</second>
+						<second>1.91979892172343747e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.82614998071476159e-02</second>
+						<second>-9.76451783548026975e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.03509008083386855e-01</second>
+						<second>-1.47267091480427381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.51979470162094654e-01</second>
+						<second>2.64936730574264168e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42928436442517137e+00</second>
+						<second>-2.75560834119575571e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84175859876266879e+00</second>
+						<second>-1.05704735788001525e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84177391663201684e+00</second>
+						<second>2.01888204106103242e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59927,34 +59927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61756878853632702e+00</second>
+						<second>1.91973973664914088e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.86699906377122261e-02</second>
+						<second>-1.39999184175704761e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.20218916113476881e-01</second>
+						<second>-1.45769052105406782e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.49393737313443298e-01</second>
+						<second>2.91732516635711381e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53831191808284728e+00</second>
+						<second>-2.86775093309297002e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.94199019084153379e+00</second>
+						<second>-1.43513408565227141e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09842732740091487e+00</second>
+						<second>2.09831494390119833e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85598567450554541e+00</score>
+				<score>1.19707869181012561e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59985,31 +59985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>-1.57420900562924637e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>4.38239100035444751e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>1.10047502916917117e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>-6.66872288109413347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>-7.85710702700686214e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>3.92807171729281424e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>9.36114342325208071e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60017,34 +60017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72000758461120018e+00</second>
+						<second>-1.73309545394624220e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79092171196493233e+00</second>
+						<second>3.71194570862286410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39742196021818588e+00</second>
+						<second>1.39075881902629872e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.47413148454069720e-01</second>
+						<second>-6.23947203518209981e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51724710219174508e+00</second>
+						<second>-6.06275528927473495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21674568778376352e-01</second>
+						<second>2.39719577501517955e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49540843094855869e+00</second>
+						<second>1.49544977691983250e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01635550381667006e+00</score>
+				<score>1.88886324331853234e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60075,31 +60075,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.76856737623272742e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>3.56782345330961814e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.76048818102965021e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-5.51185024415869917e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-3.87085904084549848e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>1.96695063438772993e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.99617064960713919e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60107,34 +60107,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73198821872575381e+00</second>
+						<second>-1.75786979074899219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.77387427231482064e+00</second>
+						<second>4.07042851871032174e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55267736899885089e+00</second>
+						<second>1.53855160060295226e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54764526485830611e-01</second>
+						<second>-6.15417519729974161e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56582802875907356e+00</second>
+						<second>-5.41172080229784136e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.33248476775721414e-01</second>
+						<second>2.68948829595595795e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66839468234949440e+00</second>
+						<second>1.66833891564881709e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88560117858544452e+00</score>
+				<score>1.80973142922320307e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60165,31 +60165,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.85507357889085078e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>2.95044344945019743e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.73494182554101672e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-3.33531372221608613e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-1.93230193836121528e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>1.63563080988759074e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>2.12630254202994262e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60197,34 +60197,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69148676600091652e+00</second>
+						<second>-1.76222184643644630e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.72504986782178538e+00</second>
+						<second>5.27581815932649523e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76258894930419108e+00</second>
+						<second>1.71675357375018978e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.89469281811751267e-01</second>
+						<second>-6.01112255601456091e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61785440888874588e+00</second>
+						<second>-4.32662379718052270e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.00677001556675205e-01</second>
+						<second>3.95826066627017914e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82332949160270608e+00</second>
+						<second>1.82325659995891032e+00</second>
 					</item>
 				</goal_state>
-				<score>2.63849304395524031e+00</score>
+				<score>1.65276199097004833e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60255,31 +60255,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75171828476251035e+00</second>
+						<second>1.91967140659188318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.97770923469155946e-01</second>
+						<second>1.36029709017956857e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91861341112589301e+00</second>
+						<second>1.58776583287951811e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63522122730981945e+00</second>
+						<second>2.87812615598219868e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.95862029121322090e+00</second>
+						<second>3.98840460189006929e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.46182334507715994e-01</second>
+						<second>-1.86354329481555925e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10289817575993876e+00</second>
+						<second>1.95440163912421450e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60287,34 +60287,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72852073786178773e+00</second>
+						<second>1.91961553153196363e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.72574429686349839e-01</second>
+						<second>1.04728023187531272e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88042130750627257e+00</second>
+						<second>1.59604321082047229e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52241255367156381e+00</second>
+						<second>2.86955785969579935e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82180386044420217e+00</second>
+						<second>-7.37701910341820172e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.48772678965251504e-01</second>
+						<second>-2.18706467803045657e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91966546418183226e+00</second>
+						<second>1.91945303457663141e+00</second>
 					</item>
 				</goal_state>
-				<score>2.38663141491819486e+00</score>
+				<score>1.50812091057994507e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60345,31 +60345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>1.66951464868607879e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-4.26537018441166399e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>-1.00647869140077262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-2.16430007432672245e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>2.27354636161148704e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>3.13844220845669986e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.49964826037106236e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60377,34 +60377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75448154560338709e+00</second>
+						<second>1.91967140659188318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.10005141276530116e+00</second>
+						<second>1.36029709017956857e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.90726415615026190e+00</second>
+						<second>1.58776583287951811e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56594157008385348e+00</second>
+						<second>2.87812615598219868e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.05647911197432354e+00</second>
+						<second>3.98840460189006929e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.24145473656550420e+00</second>
+						<second>-1.86354329481555925e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95457673655683672e+00</second>
+						<second>1.95440163912421450e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22355893659825643e+00</score>
+				<score>1.44825524609040024e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60435,31 +60435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.38760217348961268e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>1.59666266780796362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>2.75431959440804919e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>5.14575159710750143e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>1.65782920023235292e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>-1.84170784703497104e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60467,34 +60467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57494022683167900e+00</second>
+						<second>-1.91979732897159550e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.12253977106517783e-02</second>
+						<second>-1.52999278298829999e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.58206752544709039e-01</second>
+						<second>1.57907463407186355e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.82877438931468106e-01</second>
+						<second>2.82849738907276160e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42425104320007545e+00</second>
+						<second>7.17774141522565662e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.78332158770567428e+00</second>
+						<second>1.52459940685457895e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91968242144955559e+00</second>
+						<second>-1.91962271511517746e+00</second>
 					</item>
 				</goal_state>
-				<score>2.30666643850350983e+00</score>
+				<score>1.50184639543714721e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60525,31 +60525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>1.59152370992342140e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>-2.61257966702540489e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>-1.45783486703910792e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>2.27358183265915814e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>2.33053324329082034e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>-2.50984962773922460e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.07740522635630676e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60557,34 +60557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52909997632289874e+00</second>
+						<second>1.55807959740208934e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.64346866375074574e-01</second>
+						<second>-2.71352125956974444e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19465415074969039e+00</second>
+						<second>-1.18105030741075612e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33006631643473661e+00</second>
+						<second>2.40262150311872791e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27880100231522631e+00</second>
+						<second>2.31438555539744195e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03968839250120892e-01</second>
+						<second>-2.70800190772840566e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50071081065153922e-01</second>
+						<second>9.50165324122846044e-01</second>
 					</item>
 				</goal_state>
-				<score>2.65024481999949568e+00</score>
+				<score>1.66174907189244520e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60615,31 +60615,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60647,34 +60647,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63871456235047597e+00</second>
+						<second>1.63120892273518092e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.71909572797862786e+00</second>
+						<second>-2.73213527612664553e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33310262914724298e+00</second>
+						<second>-1.33711600271059639e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.08814236947989729e-01</second>
+						<second>2.41798898907624249e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40292323607469926e+00</second>
+						<second>2.39403148846554004e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.75237167160647755e-01</second>
+						<second>-2.77463264350882888e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22684857501630362e+00</second>
+						<second>1.22702852189182066e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06641290989440307e+00</score>
+				<score>1.92026779527659869e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60705,31 +60705,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>-1.75786979074899219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>4.07042851871032174e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>1.53855160060295226e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>-6.15417519729974161e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>-5.41172080229784136e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>2.68948829595595795e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.66833891564881709e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60737,34 +60737,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65931524532564079e+00</second>
+						<second>-1.68330465698098797e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69718534677328581e+00</second>
+						<second>4.84255156800691589e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53047279703550165e+00</second>
+						<second>1.51638744567603201e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.32225420554768691e-01</second>
+						<second>-6.92852771595663941e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45862291803228850e+00</second>
+						<second>-6.54681438859542664e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94338855913131836e-01</second>
+						<second>4.22438629609090732e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44335796056823518e+00</second>
+						<second>1.44343606166413241e+00</second>
 					</item>
 				</goal_state>
-				<score>3.16789136235634938e+00</score>
+				<score>1.98539816193697982e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60795,31 +60795,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72852073786178773e+00</second>
+						<second>-1.80452172515614429e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.72574429686349839e-01</second>
+						<second>4.82846140695784853e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88042130750627257e+00</second>
+						<second>1.50690841335823755e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52241255367156381e+00</second>
+						<second>-5.34508968321917299e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82180386044420217e+00</second>
+						<second>-4.74765561322760432e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.48772678965251504e-01</second>
+						<second>3.42511104532839949e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91966546418183226e+00</second>
+						<second>1.66834689392544777e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60827,34 +60827,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73942180547431557e+00</second>
+						<second>-1.71382753222648576e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.56111198208569224e-01</second>
+						<second>6.11650045681486954e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65379993408653525e+00</second>
+						<second>1.67548846289941600e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.51989583244975890e+00</second>
+						<second>-6.62363725006069659e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62942176864082855e+00</second>
+						<second>-5.41780006572172734e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78433977557595402e-01</second>
+						<second>5.43861719734553883e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.60017158372046042e+00</second>
+						<second>1.60021691042463843e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06266856717553715e+00</score>
+				<score>1.91804970628983357e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60885,31 +60885,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>-1.91966437150934688e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>-1.61634230772038401e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>1.53957998112087346e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>2.78126047951469690e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>-5.12686365273042455e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>-8.76017962448018439e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>-1.07977005877979115e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60917,34 +60917,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.87188170724670266e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>-2.07796141180183236e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.60808056738136984e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>2.74199735530696342e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>-2.78498135009262848e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>9.68359246372389681e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>-1.68127120616254211e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87498980973320117e+00</score>
+				<score>1.84144418050897513e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60975,31 +60975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.38760217348961268e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.59666266780796362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.75431959440804919e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>5.14575159710750143e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.65782920023235292e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.84170784703497104e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61007,34 +61007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.78700655754826343e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.61308236621958567e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>2.76151238881607597e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-1.91853317818620972e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.26531206625761827e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>-1.68186744777539765e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>1.84154841228309718e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61065,31 +61065,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>-1.91979732897159550e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>-1.52999278298829999e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>1.57907463407186355e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>2.82849738907276160e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>7.17774141522565662e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>1.52459940685457895e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>-1.91962271511517746e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61097,34 +61097,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.63448679196792890e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.64978545561884737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>2.72629227694931364e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.20491006717536778e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.41593233428176024e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>-1.71086301873635804e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71467833239565692e+00</score>
+				<score>1.79660441612175731e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -61245,31 +61245,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61277,34 +61277,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39759981785532950e+00</second>
+						<second>1.41382757663209002e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.45714865229058010e-01</second>
+						<second>-2.61412492875335722e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01346146480753441e+00</second>
+						<second>-1.00499127511118380e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23036085323402533e+00</second>
+						<second>2.31908569223355698e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12308627895328339e+00</second>
+						<second>2.14219438854826683e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72250877136270408e-01</second>
+						<second>-2.45527028314007012e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26405460887725074e-01</second>
+						<second>4.26450081577178786e-01</second>
 					</item>
 				</goal_state>
-				<score>1.31157476336570111e+00</score>
+				<score>8.39054244233664176e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61335,31 +61335,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>1.64146672050875919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>-2.77310727615865504e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>-1.26467978115982493e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>2.44743781856469100e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>2.41332494209795190e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>-2.84903652915304750e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22466784338844015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61367,34 +61367,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>1.54072918430515937e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>-2.64621246108533237e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>-1.25952811115306340e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>2.30886426317656968e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>2.25896534444852870e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>-2.53883368913555696e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>8.49963714926571190e-01</second>
 					</item>
 				</goal_state>
-				<score>2.53630813439910208e+00</score>
+				<score>1.64099305218841168e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61425,31 +61425,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>1.60747649486051292e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>-2.47168966961281988e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>-1.61109028190356263e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>2.08591708658869379e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>2.29725593397691297e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>-2.06029889498687657e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>7.85891450114034162e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61457,34 +61457,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>1.59165504512293388e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>-2.61231930349431796e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>-1.45776038603465907e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>2.27384421288700223e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>2.33066143152575833e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>-2.50973830020813704e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.07740520571682330e+00</second>
 					</item>
 				</goal_state>
-				<score>3.02662676986478862e+00</score>
+				<score>1.95860950697394176e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61515,31 +61515,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.79362345948912272e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>1.13204876654422759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.59772644502839500e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-6.72800604964027937e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-6.53831505002115065e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>-1.01130830892028234e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>9.35106417855317895e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61547,34 +61547,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65822714549594807e+00</second>
+						<second>-1.65438260106803336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47342485774807885e+00</second>
+						<second>6.60852969379327360e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60039573211089459e+00</second>
+						<second>1.60307812406453043e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.56036573889997765e-01</second>
+						<second>-8.63046717447035761e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42340860311383333e+00</second>
+						<second>-7.21607193917882417e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.64532141877542260e-01</second>
+						<second>7.61207686818452967e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18894872780715799e+00</second>
+						<second>1.18894832469836054e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29101159047427227e+00</score>
+				<score>2.06962000055938594e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61605,31 +61605,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91966437150934688e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.61634230772038401e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.53957998112087346e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>2.78126047951469690e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-5.12686365273042455e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>-8.76017962448018439e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>-1.07977005877979115e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61637,34 +61637,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80997196953296724e+00</second>
+						<second>-1.78400780729564201e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.13396736033743251e+00</second>
+						<second>-2.18875460002261102e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62934275283419061e+00</second>
+						<second>1.65705089195764343e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.43913050759826389e+00</second>
+						<second>2.38295107059576283e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57578701736583193e+00</second>
+						<second>-5.84454693638339129e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.10567519364315547e+00</second>
+						<second>1.00631128759165955e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22484651217601614e+00</second>
+						<second>-1.22481374500049611e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17211517225196893e+00</score>
+				<score>2.09364127944422329e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61695,31 +61695,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>-1.91497235164708268e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-1.70464635657659613e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>1.65730142331107966e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.64990483148188805e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>-3.08358163054050560e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>1.38872368259695866e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>-1.44912563363703750e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61727,34 +61727,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85615876821629033e+00</second>
+						<second>-1.91979938136472206e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94799669740892334e+00</second>
+						<second>-1.79489811118172682e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68646863029297123e+00</second>
+						<second>1.58703289354959454e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.35376135257657126e-01</second>
+						<second>2.67782988296723179e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69573122035149648e+00</second>
+						<second>-4.15116432835795079e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19406712922579050e+00</second>
+						<second>1.30247388545319209e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32815184007931286e+00</second>
+						<second>-1.32795247547596840e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25819673487709194e+00</score>
+				<score>2.09606763334988649e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -62325,31 +62325,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>1.60737385704258062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>-2.47196051747263557e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>-1.61115315439674456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>2.08565371077568917e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>2.29717662647831977e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>-2.06035670193928189e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>7.85891347050963862e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -62357,34 +62357,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>1.55039769876709621e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>-2.49335830466708153e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>-1.41050778771040242e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>2.10959868196802569e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>2.18171399671336141e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>-2.02680323101411730e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.79007639214927949e-01</second>
 					</item>
 				</goal_state>
-				<score>1.68196193634369906e+00</score>
+				<score>1.15332833726483355e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -62415,31 +62415,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>1.55039769876709621e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>-2.49335830466708153e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>-1.41050778771040242e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>2.10959868196802569e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>2.18171399671336141e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>-2.02680323101411730e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.79007639214927949e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -62447,34 +62447,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60553799279419107e+00</second>
+						<second>1.60747649486051292e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47680080436684502e+00</second>
+						<second>-2.47168966961281988e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61227029635699903e+00</second>
+						<second>-1.61109028190356263e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06063164732243509e+00</second>
+						<second>2.08591708658869379e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29575687813833662e+00</second>
+						<second>2.29725593397691297e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08020164313792755e+00</second>
+						<second>-2.06029889498687657e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891741628480966e-01</second>
+						<second>7.85891450114034162e-01</second>
 					</item>
 				</goal_state>
-				<score>2.47626754124628601e+00</score>
+				<score>1.74420039925367559e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -64305,31 +64305,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.39077572316472042e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>-3.92563083824212788e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>1.02499157594024637e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>9.66198463097224458e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>1.02723109791817535e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-6.58146988257781285e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>4.41091804065838977e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64337,34 +64337,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36223008327579698e+00</second>
+						<second>-1.37453232547675697e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08419268174871974e-01</second>
+						<second>-3.60516009999356291e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74703776989244264e-01</second>
+						<second>9.70473733341461364e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87858018607627009e-01</second>
+						<second>9.29733342083889136e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02832293142760278e+00</second>
+						<second>1.01359740820754185e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69616581662928834e-01</second>
+						<second>-5.78427793341514174e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56093307037337636e-01</second>
+						<second>4.56093481952711266e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35710861655873294e+00</score>
+				<score>8.52927465193795420e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -64665,31 +64665,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36223008327579698e+00</second>
+						<second>-1.37453232547675697e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08419268174871974e-01</second>
+						<second>-3.60516009999356291e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74703776989244264e-01</second>
+						<second>9.70473733341461364e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87858018607627009e-01</second>
+						<second>9.29733342083889136e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02832293142760278e+00</second>
+						<second>1.01359740820754185e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69616581662928834e-01</second>
+						<second>-5.78427793341514174e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56093307037337636e-01</second>
+						<second>4.56093481952711266e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64697,34 +64697,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36127935133649247e+00</second>
+						<second>-1.37385974190030202e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64227526355316933e-01</second>
+						<second>-3.14843293967909776e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61608411318528389e-01</second>
+						<second>8.57721250246744726e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.46207584370517996e-01</second>
+						<second>8.86865982334050895e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.90006585311990484e-01</second>
+						<second>9.72822570437091194e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37035489445765757e-01</second>
+						<second>-4.46864709170974761e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257740756825914e-01</second>
+						<second>4.69258452332312226e-01</second>
 					</item>
 				</goal_state>
-				<score>1.25329986032945406e+00</score>
+				<score>7.86958086613569058e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -64755,31 +64755,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.66269106656973942e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>-2.64469545314780008e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>1.42319641651896656e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>7.40366050372893270e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>6.98353796952216999e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-1.49167566094834420e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>1.49989097034685304e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64787,34 +64787,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49134999512002620e+00</second>
+						<second>-1.53103810805961871e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54309693019022454e-01</second>
+						<second>-3.32076528744577160e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15053502511844430e+00</second>
+						<second>1.13728269219177558e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87098605604662915e-01</second>
+						<second>7.95896583803538782e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94498875682213979e-01</second>
+						<second>8.46702823431431550e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02843607090383937e-01</second>
+						<second>-3.38594609215859210e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577558907366618e-01</second>
+						<second>9.53268590377908565e-01</second>
 					</item>
 				</goal_state>
-				<score>2.56203644999462776e+00</score>
+				<score>1.60978640525937605e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -64845,31 +64845,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.70376908905464974e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>-1.79278557007483602e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>1.15787920958422097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>6.08230408960001134e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>6.12266801857534237e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-1.66802025071915057e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>1.37494075727534337e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64877,34 +64877,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64888339505604864e+00</second>
+						<second>-1.62256730971762742e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75682184723469170e+00</second>
+						<second>-3.38985148100858336e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26193275250488424e+00</second>
+						<second>1.27422896175999645e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46315423693026769e+00</second>
+						<second>7.32055278089110417e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42313967424857468e+00</second>
+						<second>7.52584201043933976e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83605072481505216e+00</second>
+						<second>-2.74487717461867342e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22314063803218565e+00</second>
+						<second>1.22318084304260455e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96806835776201261e+00</score>
+				<score>1.86333936722743232e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -65115,31 +65115,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49132019866036036e+00</second>
+						<second>-1.51182890904833145e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54253477600731304e-01</second>
+						<second>-3.17845455087575446e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15054332515347069e+00</second>
+						<second>1.21067322481762241e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87164314367234197e-01</second>
+						<second>8.60538519859153084e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94533768256409623e-01</second>
+						<second>8.83879653205441707e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02819284496538832e-01</second>
+						<second>-3.77499978593620000e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577580936474156e-01</second>
+						<second>9.66603655478871615e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65147,34 +65147,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.50069115291992561e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>-2.21927701658872351e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>9.40268824218865484e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>7.72505240803559090e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>8.26926994981713070e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-1.91001957404180300e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>8.52748335882003938e-01</second>
 					</item>
 				</goal_state>
-				<score>2.09137228757285731e+00</score>
+				<score>1.31210605639560746e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65205,31 +65205,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.60893366980021035e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>-1.65758058040640643e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>9.34536036240498080e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.20512807827303114e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>6.63463543265775724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-4.52957191441075643e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04812382891606970e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65237,34 +65237,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66110631140187404e+00</second>
+						<second>-1.62853283277509719e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81899582271532356e+00</second>
+						<second>-2.67840691212113735e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15444144382355574e+00</second>
+						<second>1.16772184674885748e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51833261420991583e+00</second>
+						<second>6.94724424001512353e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46862437408077451e+00</second>
+						<second>7.20456453034804212e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93814903269952898e+00</second>
+						<second>-1.61309654996585200e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21459551553429690e+00</second>
+						<second>1.21465779491493309e+00</second>
 					</item>
 				</goal_state>
-				<score>2.81168540436485559e+00</score>
+				<score>1.76360755573808065e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65295,31 +65295,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>-1.70376908905464974e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>-1.79278557007483602e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>1.15787920958422097e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>6.08230408960001134e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>6.12266801857534237e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>-1.66802025071915057e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>1.37494075727534337e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65327,34 +65327,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.68176647311880867e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>-2.76962017879322842e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>1.32285102398769583e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>6.87717220762401493e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>6.73445976093634879e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>-1.48123253427981549e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.42486751582557614e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98209612723430562e+00</score>
+				<score>1.86739988025573150e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -65475,31 +65475,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.49939149506772273e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>-2.19207510247746484e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>9.40571052046941136e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>7.76385816250054095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>8.28938824340800018e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-1.89814483432983794e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>8.52573894969098522e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65507,34 +65507,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41189264396965908e+00</second>
+						<second>-1.42291385845738305e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.05468198008550576e-01</second>
+						<second>-1.39311460581409641e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.70883652212576176e-01</second>
+						<second>6.69177790044527931e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.71716109550342422e-01</second>
+						<second>7.22971055457804157e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.94461038894873739e-01</second>
+						<second>7.72255358548982529e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.19296869967734878e-01</second>
+						<second>-1.31318625539305844e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.74910815261078900e-01</second>
+						<second>5.74900221331326899e-01</second>
 					</item>
 				</goal_state>
-				<score>1.17856655723610326e+00</score>
+				<score>7.38824916407797433e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65565,31 +65565,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.62827389672696854e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>-2.67098769350333554e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>1.16770588221971394e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.95939954387115645e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>7.21251838364953213e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.61211154177438587e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.21428475767838018e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65597,34 +65597,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.60893366980021035e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>-1.65758058040640643e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>9.34536036240498080e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.20512807827303114e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>6.63463543265775724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-4.52957191441075643e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04812382891606970e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32029742004960582e+00</score>
+				<score>1.45556649257872206e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65655,31 +65655,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.69077391746664718e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>-6.86670762237855670e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>9.20523713720079351e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>4.93744253231816088e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>5.01826141251839442e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>7.09763288072463860e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.18061999661530992e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65687,34 +65687,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74137046169233978e+00</second>
+						<second>-1.71991755584287587e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90482152295904550e+00</second>
+						<second>-2.03172958269580151e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14552536569234165e+00</second>
+						<second>1.15320339340978073e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.61794406177421202e+00</second>
+						<second>5.73499839687012236e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59397938466180022e+00</second>
+						<second>5.85409264098134763e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06511774149403760e+00</second>
+						<second>-4.09270293856393436e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.37508332433671066e+00</second>
+						<second>1.37504790228914953e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79910347740579413e+00</score>
+				<score>1.75250749015908841e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65745,31 +65745,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>3.22466809392819090e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>1.29118645977406321e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>2.73533701744509972e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>2.45277900030728691e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>1.63179721082602758e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>1.80272725970511782e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65777,34 +65777,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69962806469953653e+00</second>
+						<second>-1.81639346626238929e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.12469469834475658e-01</second>
+						<second>-2.71969617190622237e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36263387108325040e+00</second>
+						<second>1.32822604210319062e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.91514445066621630e-01</second>
+						<second>4.90397848553668692e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.49379348199519368e-01</second>
+						<second>4.69605688869574156e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.47141003672900511e-02</second>
+						<second>-1.01728377393437319e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62546111558521700e+00</second>
+						<second>1.62518737808456071e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78357441156326457e+00</score>
+				<score>1.75574324863541825e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65835,31 +65835,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75710114345983048e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.78689810643983138e-03</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55873961545851691e+00</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.85552513694617471e-01</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.43777858502480393e-01</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.25562014398732524e-01</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562695644893926e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65867,34 +65867,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72571976044136144e+00</second>
+						<second>-1.88219116882354198e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.58020683904094184e-02</second>
+						<second>-2.89686473085348672e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46594022777492938e+00</second>
+						<second>1.41907802904888869e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.62602685770425359e-01</second>
+						<second>3.96524219064764649e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.09167610231513001e-01</second>
+						<second>3.47644655334275243e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41613173692224009e-01</second>
+						<second>-1.31106635159709523e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79453085865062878e+00</second>
+						<second>1.79454038869930854e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56969598985473446e+00</score>
+				<score>1.62266563831180488e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -66015,31 +66015,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54366507048984825e+00</second>
+						<second>-1.57784031083916076e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.56105009648136617e-01</second>
+						<second>8.29935905838286164e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.50071567907060555e-01</second>
+						<second>6.57342279747295533e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.60510964856758997e-01</second>
+						<second>4.11900272785284849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.52449647592566340e-01</second>
+						<second>3.50453375393860678e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.84744376758726347e-01</second>
+						<second>1.19670943549623446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40257492939055717e-01</second>
+						<second>8.39878036607591749e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66047,34 +66047,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50720012175455964e+00</second>
+						<second>-1.54035621291649494e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80543303923708985e-02</second>
+						<second>-1.13063531710869039e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.76852059960830088e-01</second>
+						<second>6.72853336678132963e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06296680019806633e-01</second>
+						<second>4.57896280009188250e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.00703847118595369e-01</second>
+						<second>5.11354659811820156e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.68336331601377008e-02</second>
+						<second>-2.95538239227609995e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.55794078425478966e-01</second>
+						<second>7.55688816816867059e-01</second>
 					</item>
 				</goal_state>
-				<score>1.46960150185848848e+00</score>
+				<score>9.23966948679428579e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66105,31 +66105,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.55905707948953820e+00</second>
+						<second>-1.57784031083916076e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>8.29935905838286164e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.66626876561165815e-01</second>
+						<second>6.57342279747295533e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.79161999085778900e+00</second>
+						<second>4.11900272785284849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.69447138737248126e+00</second>
+						<second>3.50453375393860678e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06831516715105490e+00</second>
+						<second>1.19670943549623446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.54790739581616799e-01</second>
+						<second>8.39878036607591749e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66137,34 +66137,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74298356744245009e+00</second>
+						<second>-1.69857769823108629e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-8.22519840610152070e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.06206470043442125e-01</second>
+						<second>9.19499015044044410e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84705709009621799e+00</second>
+						<second>4.69493717725192161e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78494963219267921e+00</second>
+						<second>4.83591949621516359e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08647807770610738e+00</second>
+						<second>5.58871544072318815e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18002683311874246e+00</second>
+						<second>1.18059100763519198e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40061118769434723e+00</score>
+				<score>1.50523012027022507e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66195,31 +66195,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66227,34 +66227,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73146196099327043e+00</second>
+						<second>-1.84861394341195551e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.66459655639824785e-03</second>
+						<second>-1.71843808419602478e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13181020475308580e+00</second>
+						<second>1.11249788555076412e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.99462277474732019e-01</second>
+						<second>2.89666037788184116e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.67371889319369882e-01</second>
+						<second>3.10805930517407958e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.06690371059819383e-01</second>
+						<second>-4.33838397483457192e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49773933841123230e+00</second>
+						<second>1.49774449831762735e+00</second>
 					</item>
 				</goal_state>
-				<score>2.67290253440225278e+00</score>
+				<score>1.69914175326464106e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66285,31 +66285,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.89993169951702212e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-3.23791661917088469e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.40648800103529537e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>3.49912339711138387e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>3.07424490351773327e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>-1.78817560425712507e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.79451128510084312e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66317,34 +66317,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.91979295133854899e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-2.26203895976568981e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.29915859570457881e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>2.45809620043798777e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>2.35084678396318469e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>-1.11221305389251429e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.74758215247544113e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55648081361388524e+00</score>
+				<score>1.63178973736888056e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66375,31 +66375,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.88951122866370858e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-4.41553841606146594e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.09465064275616486e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>1.28603492427445176e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>1.29720808812315958e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>1.69427832913690221e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.54908011504979415e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66407,34 +66407,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76872490052123710e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.25957736005298118e-02</second>
+						<second>-1.75309176008467432e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44629760263244767e+00</second>
+						<second>1.42796022395593081e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92944299624998505e-01</second>
+						<second>3.05323477431356627e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.57318024282256630e-01</second>
+						<second>2.60457444489645307e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84525772214657191e-01</second>
+						<second>-3.73158461658395849e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.88873698038749560e+00</second>
+						<second>1.88861615951196815e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34946708802678073e+00</score>
+				<score>1.49948883203201211e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -66555,31 +66555,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>-1.77931960537727907e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>-2.91590312979969762e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>8.92141134199485486e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>1.73086454282706498e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>1.77884321178655908e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>3.57513453418853086e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>1.23906532703622840e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66587,34 +66587,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54836850645436463e+00</second>
+						<second>-1.61119506425996284e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47154316534740870e-01</second>
+						<second>-3.43019431789279017e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.51223582139097590e-01</second>
+						<second>6.59797974393668052e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.42354329574008531e-01</second>
+						<second>1.70786143331421642e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.39904689182011144e-01</second>
+						<second>1.87833574569147344e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.77089419744559662e-01</second>
+						<second>8.56535816084323144e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40237716644574251e-01</second>
+						<second>8.39896916292141360e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53525067035784879e+00</score>
+				<score>9.88112660264477555e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66645,31 +66645,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>-1.88951122866370858e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>-4.41553841606146594e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>1.09465064275616486e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>1.28603492427445176e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>1.29720808812315958e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>1.69427832913690221e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>1.54908011504979415e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66677,34 +66677,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>-1.78410875917516387e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>-4.98739057835781360e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>8.90990056916295181e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>1.27097743941404745e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>1.43327099822681242e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>3.60084142410167915e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>1.23893139423867304e+00</second>
 					</item>
 				</goal_state>
-				<score>2.33463818253786748e+00</score>
+				<score>1.50819503707228353e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66735,31 +66735,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>-1.79023238736312296e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>7.66277651665690368e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>8.91449596998698857e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>-6.17227441767584512e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>-9.23624068696897033e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>3.99374878159626592e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>1.24405581989377167e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66767,34 +66767,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61950156365418230e+00</second>
+						<second>-1.89417604647923810e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97454211628675858e-01</second>
+						<second>-6.98119036162254958e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02773810783669828e+00</second>
+						<second>1.09237220822296965e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.36019588830926397e+00</second>
+						<second>7.40029624083290566e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.12965777391745381e-01</second>
+						<second>8.64780459742751084e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.57881466548512783e+00</second>
+						<second>-3.02749809775045946e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.54904188803764042e+00</second>
+						<second>1.54897967173109974e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41860131399776090e+00</score>
+				<score>1.66392190918488864e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66825,31 +66825,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>-1.91978974421507886e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>-1.75499366037569965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>1.42798021628105753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>3.05066740233359834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>2.60206717442609092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>-3.76482338938168015e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>1.88868002277531399e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66857,34 +66857,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64465585611466958e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.39718353539401885e-01</second>
+						<second>3.22466809392819090e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20256292724274050e+00</second>
+						<second>1.29118645977406321e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39565903761189469e+00</second>
+						<second>2.73533701744509972e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.33770541736491033e-01</second>
+						<second>2.45277900030728691e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.48777058420238362e+00</second>
+						<second>1.63179721082602758e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80306926692887415e+00</second>
+						<second>1.80272725970511782e+00</second>
 					</item>
 				</goal_state>
-				<score>2.28140253301627238e+00</score>
+				<score>1.55361798806179480e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66915,31 +66915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66947,34 +66947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64619669247399325e+00</second>
+						<second>-1.91979999303321858e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.88432768533887807e-01</second>
+						<second>6.77216429461324210e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31758894412218308e+00</second>
+						<second>1.42638334939898925e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43687907238766943e+00</second>
+						<second>2.99961868638436491e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.45695751063011558e-01</second>
+						<second>2.74841333305086255e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.43028504085827768e+00</second>
+						<second>2.15210678445649811e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95503282063708461e+00</second>
+						<second>1.95464598730574157e+00</second>
 					</item>
 				</goal_state>
-				<score>2.06597250747945482e+00</score>
+				<score>1.39514017611240076e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -67095,31 +67095,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65935318302968660e+00</second>
+						<second>-1.76693626184754216e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.81229934056232403e-02</second>
+						<second>2.59073833390813135e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23426921659290190e-01</second>
+						<second>8.86321789193149190e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55886758024092398e+00</second>
+						<second>-1.21202026349732331e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57382342392445596e+00</second>
+						<second>-2.33328010901128952e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.27152848376685529e-01</second>
+						<second>1.66957517093525326e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18296119694657120e+00</second>
+						<second>1.18282973177588779e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67127,34 +67127,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54999363363824072e+00</second>
+						<second>-1.61624947912674899e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.40485457829517990e-01</second>
+						<second>8.95628806419516976e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.51268592557595616e-01</second>
+						<second>6.56252711412286249e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.60882023109323580e+00</second>
+						<second>-5.98779885674351753e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70734578584733310e+00</second>
+						<second>-1.15129760447289495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.70995644968146204e-01</second>
+						<second>4.46234390821319965e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.38228589719372530e-01</second>
+						<second>8.38239291281499432e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53370612056787081e+00</score>
+				<score>9.83601440545702060e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67185,31 +67185,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73996181694739382e+00</second>
+						<second>-1.88778876760432190e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41229827306441139e-02</second>
+						<second>4.57656304846310036e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12838484187793964e+00</second>
+						<second>1.09153301701095362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56236271816107708e+00</second>
+						<second>-1.30963118920434829e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.59042257284734845e+00</second>
+						<second>-1.32773318777351990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.80263047342040933e-01</second>
+						<second>-1.64539777210562302e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48699258630051001e+00</second>
+						<second>1.54408793513391629e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67217,34 +67217,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70134941636534709e+00</second>
+						<second>-1.78598381195630118e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30243420063538839e-01</second>
+						<second>4.63647333221223479e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84399091838568463e-01</second>
+						<second>8.93804666009685445e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63256653815908237e+00</second>
+						<second>-1.27529722078762869e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70388791440015375e+00</second>
+						<second>-1.42098508971873150e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.65452915922833155e-01</second>
+						<second>-6.70529421557361678e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24448354148807572e+00</second>
+						<second>1.24405157446068482e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34944416305658743e+00</score>
+				<score>1.51253961635647777e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67275,31 +67275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67625567210292359e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61960506364601520e-01</second>
+						<second>2.27651665749751125e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.78083761912612393e-01</second>
+						<second>1.30212768513526611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56642561142902892e+00</second>
+						<second>-2.48197394159179130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64997149645367847e+00</second>
+						<second>-2.37106221436600761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07293225787140800e-01</second>
+						<second>1.11407491644512760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24415705776787799e+00</second>
+						<second>1.74971646012369497e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67307,34 +67307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75687257357049575e+00</second>
+						<second>-1.88778876760432190e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.74018203165185459e-01</second>
+						<second>4.57656304846310036e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07026347532716670e+00</second>
+						<second>1.09153301701095362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57636530400940744e+00</second>
+						<second>-1.30963118920434829e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64059533251779133e+00</second>
+						<second>-1.32773318777351990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.84840448906571209e-01</second>
+						<second>-1.64539777210562302e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.54399232674553488e+00</second>
+						<second>1.54408793513391629e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41662736443792037e+00</score>
+				<score>1.66394210944927262e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67365,31 +67365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73715829499825447e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.31874036502090752e-01</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20538534307321155e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52777638627188850e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.16582545185260789e-01</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27889349678314224e+00</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95356289603521227e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67397,34 +67397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72211726669378384e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.86490093379832733e-01</second>
+						<second>-2.60787998308611157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09436750628503887e+00</second>
+						<second>1.28944902899844838e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48287753893405450e+00</second>
+						<second>-2.72108607592937646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.97532130404137107e-01</second>
+						<second>-2.44427527468376232e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33974610013822426e+00</second>
+						<second>-1.56244456315562913e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79943072227715772e+00</second>
+						<second>1.79914746700753536e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19808988873429856e+00</score>
+				<score>1.55738442176841796e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67455,31 +67455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64397562085141113e+00</second>
+						<second>-1.88110321539179370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.90431335606353291e-01</second>
+						<second>1.01339412836803588e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31609272618829398e+00</second>
+						<second>1.73047566985697276e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43425117612246478e+00</second>
+						<second>-1.13606579453618406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.48905466185118773e-01</second>
+						<second>-6.34558061192635747e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.42760024651516648e+00</second>
+						<second>5.13420073155334486e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95478867818194790e+00</second>
+						<second>2.19857982173747502e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67487,34 +67487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73715829499825447e+00</second>
+						<second>-1.91979998920085970e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.31874036502090752e-01</second>
+						<second>-6.33343952486098566e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20538534307321155e+00</second>
+						<second>1.42630038431658246e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52777638627188850e+00</second>
+						<second>-3.00205537285980317e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.16582545185260789e-01</second>
+						<second>-2.75013813972306009e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27889349678314224e+00</second>
+						<second>-2.10849100615314977e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95356289603521227e+00</second>
+						<second>1.95327428161838190e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00557675314476125e+00</score>
+				<score>1.39728522899241175e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -67635,31 +67635,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60432212994440104e+00</second>
+						<second>-1.66298031776517696e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52321327387608924e-01</second>
+						<second>2.64898862554590331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45179492403312227e-01</second>
+						<second>9.25422856477156830e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49801098922233633e+00</second>
+						<second>-4.65152880647415334e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46389592936861757e+00</second>
+						<second>-5.61487872423004131e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.33218681738235017e-02</second>
+						<second>1.28031652205075452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06027418642082738e+00</second>
+						<second>1.06041149324859507e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67667,34 +67667,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50790635279612384e+00</second>
+						<second>-1.54581943360560570e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.27036491441373353e-02</second>
+						<second>1.37811586900076999e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.68178305180508914e-01</second>
+						<second>6.62345305855326361e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55508537688013249e+00</second>
+						<second>-4.01821170175490960e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55687353397126627e+00</second>
+						<second>-4.74128308006810995e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.25615090816895722e-02</second>
+						<second>4.77289875601672811e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.46005765230304596e-01</second>
+						<second>7.46038758620586662e-01</second>
 					</item>
 				</goal_state>
-				<score>1.43999004478396553e+00</score>
+				<score>9.04635196079511400e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67725,31 +67725,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68808114415395027e+00</second>
+						<second>-1.76202718338374842e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47673657223877791e-01</second>
+						<second>2.59701371844060391e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16446586361639270e+00</second>
+						<second>1.14023975774218878e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49879072446559158e+00</second>
+						<second>-4.77360381083251406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50414336959512163e+00</second>
+						<second>-5.10196231861515415e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.76544409128169370e-02</second>
+						<second>1.01637485709889869e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38492865636368911e+00</second>
+						<second>1.38462206299788204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67757,34 +67757,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66493864038840234e+00</second>
+						<second>-1.72094678133596957e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.64049791182816782e-02</second>
+						<second>1.20885800055134995e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23348468566452363e-01</second>
+						<second>9.15649816160100105e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57371020971062547e+00</second>
+						<second>-3.93085868508316782e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58515255359326046e+00</second>
+						<second>-4.26478854823201137e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.18546481179678184e-01</second>
+						<second>-1.04703139305917150e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18312779682388003e+00</second>
+						<second>1.18299612626846828e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39200751925229671e+00</score>
+				<score>1.50869743022856329e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67815,31 +67815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68808114415395027e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47673657223877791e-01</second>
+						<second>1.75981530636056344e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16446586361639270e+00</second>
+						<second>1.42985363523912268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49879072446559158e+00</second>
+						<second>-3.04977127449779617e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50414336959512163e+00</second>
+						<second>-2.60074595166043088e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.76544409128169370e-02</second>
+						<second>3.81682728189809140e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38492865636368911e+00</second>
+						<second>1.89041868763930565e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67847,34 +67847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74730105002795311e+00</second>
+						<second>-1.84483704577558361e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31279750608886919e-02</second>
+						<second>1.78464983139539374e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12815762385272533e+00</second>
+						<second>1.10792997155307527e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57721528822870471e+00</second>
+						<second>-2.93575649178586973e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.60325952270787031e+00</second>
+						<second>-3.16940588637338039e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.68734127418638552e-01</second>
+						<second>4.90431435805776250e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48701123194171880e+00</second>
+						<second>1.48699517324951680e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68569520792969518e+00</score>
+				<score>1.70007143387948978e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67905,31 +67905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.89370845030693258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>8.12531053875442388e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>1.08805217359821604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-5.52572251105149653e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-7.29396367122635142e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>4.88102630171112634e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.54396529490870771e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67937,34 +67937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>2.27651665749751125e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.30212768513526611e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-2.48197394159179130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-2.37106221436600761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.11407491644512760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.74971646012369497e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55544347897950264e+00</score>
+				<score>1.63087470460675066e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67995,31 +67995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.88778876760432190e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>4.57656304846310036e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.09153301701095362e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-1.30963118920434829e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-1.32773318777351990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>-1.64539777210562302e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.54408793513391629e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68027,34 +68027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>1.75981530636056344e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.42985363523912268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-3.04977127449779617e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.60074595166043088e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>3.81682728189809140e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.89041868763930565e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34645678975905270e+00</score>
+				<score>1.49757071336205805e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -68175,31 +68175,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51330263842823332e+00</second>
+						<second>-1.56977669770507222e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45503843151062440e-01</second>
+						<second>3.81742909179496770e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.39483124730225216e-01</second>
+						<second>9.14695959636713241e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40109970179178100e+00</second>
+						<second>-5.55313803575095077e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33227023842397063e+00</second>
+						<second>-7.14075935770212000e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01882743133928066e-01</second>
+						<second>2.76461172205838601e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56960312185424677e-01</second>
+						<second>8.56864150627536514e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68207,34 +68207,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.42874672944860848e+00</second>
+						<second>-1.46358585107289918e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.64711874275887765e-01</second>
+						<second>2.97425355375174449e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63789757764832955e-01</second>
+						<second>6.51343832405297363e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45636582181556484e+00</second>
+						<second>-4.93706080076008025e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38632999381627364e+00</second>
+						<second>-6.69763542474516416e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41383692371532227e-01</second>
+						<second>1.93798119509122041e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.69245659440157814e-01</second>
+						<second>5.69050208701738724e-01</second>
 					</item>
 				</goal_state>
-				<score>1.16318290980713490e+00</score>
+				<score>7.22448393326521332e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68265,31 +68265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>-1.67815669516476595e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>3.61966022750501271e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>1.14376816014988458e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>-5.78038621726574164e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>-6.46232615503754104e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>2.38048434011439575e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.20709036163051575e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68297,34 +68297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60457722747064335e+00</second>
+						<second>-1.65440851764489438e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52889873101456270e-01</second>
+						<second>2.46278669696861324e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45210298323762022e-01</second>
+						<second>9.29449568893965794e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49918105216335507e+00</second>
+						<second>-4.95182266941773530e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46461610046384205e+00</second>
+						<second>-5.80696294123980827e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.35275043253553673e-02</second>
+						<second>1.11518431699867013e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06052502812255312e+00</second>
+						<second>1.06043132946227026e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34753557561738679e+00</score>
+				<score>1.46970253259915529e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68355,31 +68355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>-1.57420900562924637e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>4.38239100035444751e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>1.10047502916917117e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>-6.66872288109413347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>-7.85710702700686214e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>3.92807171729281424e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>9.36114342325208071e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68387,34 +68387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73694904272654216e+00</second>
+						<second>-1.74396615608298489e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.92326421045417906e+00</second>
+						<second>2.29311051209690253e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15068219662851279e+00</second>
+						<second>1.14803779736578360e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.40079300316176014e-01</second>
+						<second>-5.23586433352998704e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58429332717227744e+00</second>
+						<second>-5.44803531947952613e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.57959050943139037e-02</second>
+						<second>6.77960160301625536e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.38463018502307267e+00</second>
+						<second>1.38457548444547984e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79776770123972574e+00</score>
+				<score>1.75263320860488819e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68445,31 +68445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-1.68137492820136480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>4.42031406181965625e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>1.24237689871449497e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>-6.05475390264391566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-6.73581245110314142e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>3.45384554276136679e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>1.22462593686467991e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68477,34 +68477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.81753454104301815e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.76063911201914203e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.32445885762265769e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-4.86237709657061090e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-4.67224215403979959e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.06762728293344447e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.62083999908622967e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80047577822184390e+00</score>
+				<score>1.75805546389311840e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68535,31 +68535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71670712376820056e+00</second>
+						<second>-1.86276796520798915e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.79003587336505066e-01</second>
+						<second>3.69856741868815453e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45375954288232201e+00</second>
+						<second>1.51684807570517100e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46477275640420990e+00</second>
+						<second>-4.42469711861834869e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51932267323400350e+00</second>
+						<second>-3.62933975797751662e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03120276869565509e-03</second>
+						<second>2.10460781383860929e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68403153904001113e+00</second>
+						<second>1.83808528308782404e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68567,34 +68567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76387218518463307e+00</second>
+						<second>-1.88998194318797830e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04385140963515533e-01</second>
+						<second>2.94214754404261813e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46364388490693775e+00</second>
+						<second>1.41871748906840289e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52978903390368748e+00</second>
+						<second>-3.79507397312765171e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58778388074027976e+00</second>
+						<second>-3.30433658424182264e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00004754114545027e-01</second>
+						<second>1.39771497916728965e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80318063824447816e+00</second>
+						<second>1.80317861525538325e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56191824615771191e+00</score>
+				<score>1.61274637083333228e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -68805,31 +68805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>1.64146672050875919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>-2.77310727615865504e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>-1.26467978115982493e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>2.44743781856469100e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>2.41332494209795190e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>-2.84903652915304750e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>1.22466784338844015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68837,34 +68837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51330263842823332e+00</second>
+						<second>1.54634708222809825e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45503843151062440e-01</second>
+						<second>-2.82034897756241554e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.39483124730225216e-01</second>
+						<second>-9.27031818154631870e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40109970179178100e+00</second>
+						<second>2.50342610539703037e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33227023842397063e+00</second>
+						<second>2.38548658977654160e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01882743133928066e-01</second>
+						<second>-2.89958020699903285e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56960312185424677e-01</second>
+						<second>8.56947629472107342e-01</second>
 					</item>
 				</goal_state>
-				<score>2.10312932549662834e+00</score>
+				<score>1.31495337360994058e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68895,31 +68895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60432212994440104e+00</second>
+						<second>1.64146672050875919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52321327387608924e-01</second>
+						<second>-2.77310727615865504e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45179492403312227e-01</second>
+						<second>-1.26467978115982493e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49801098922233633e+00</second>
+						<second>2.44743781856469100e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46389592936861757e+00</second>
+						<second>2.41332494209795190e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.33218681738235017e-02</second>
+						<second>-2.84903652915304750e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06027418642082738e+00</second>
+						<second>1.22466784338844015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68927,34 +68927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>1.65015466533820399e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>-2.82999671323725499e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>-1.15757702082347347e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>2.49632057406694718e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>2.45213774072890756e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>-2.94346844572075961e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.20699013027369806e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80975630011534427e+00</score>
+				<score>1.76146256165789605e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68985,31 +68985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>1.64146672050875919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>-2.77310727615865504e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>-1.26467978115982493e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>2.44743781856469100e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>2.41332494209795190e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>-2.84903652915304750e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.22466784338844015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69017,34 +69017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>1.70354102305588806e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>-2.83226402422404666e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>-1.31375056755538022e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>2.49303803619023201e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>2.49803875381359752e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>-2.96583480259275989e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>1.42472051422526258e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98187466200491524e+00</score>
+				<score>1.86788986153511832e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -69345,31 +69345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69377,34 +69377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38678655319987110e+00</second>
+						<second>1.40424342607910413e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.65052216112931927e-01</second>
+						<second>-2.69797980669551540e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.57367522993721987e-01</second>
+						<second>-8.49007350736283195e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31181443074315540e+00</second>
+						<second>2.40354836645144232e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18546025666860277e+00</second>
+						<second>2.21129310688245040e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.58382262714206234e-01</second>
+						<second>-2.66550086304911327e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73062456092897821e-01</second>
+						<second>4.73057577059559531e-01</second>
 					</item>
 				</goal_state>
-				<score>1.26524191534659414e+00</score>
+				<score>7.92357270178497136e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -69435,31 +69435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69467,34 +69467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52413979837612534e+00</second>
+						<second>1.55892494532276427e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.28152527918693759e-01</second>
+						<second>-2.73814628114512937e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12452626419333401e+00</second>
+						<second>-1.10897932319746473e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34116611895166127e+00</second>
+						<second>2.43157681516576174e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.28991850224467264e+00</second>
+						<second>2.33515260362883659e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.38119975227272440e-01</second>
+						<second>-2.76644852931949892e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36118128040124842e-01</second>
+						<second>9.36166959538184074e-01</second>
 					</item>
 				</goal_state>
-				<score>2.52323493338123273e+00</score>
+				<score>1.58064748016110312e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -69525,31 +69525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69557,34 +69557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59810989599078579e+00</second>
+						<second>1.64255108077556811e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96473804212760261e-01</second>
+						<second>-2.77051861172280356e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28282700582325404e+00</second>
+						<second>-1.26422792581743249e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36326996285087398e+00</second>
+						<second>2.45007575886660867e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35904914937748966e+00</second>
+						<second>2.41523385394140089e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45176015426882166e-01</second>
+						<second>-2.84711299592109768e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22484571923982077e+00</second>
+						<second>1.22487663134414460e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96501439914651321e+00</score>
+				<score>1.86219895760671911e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -69975,31 +69975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39776116547487450e+00</second>
+						<second>1.64146672050875919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.46742538136349676e-01</second>
+						<second>-2.77310727615865504e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01345139506047777e+00</second>
+						<second>-1.26467978115982493e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23123050539687284e+00</second>
+						<second>2.44743781856469100e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12332802065480664e+00</second>
+						<second>2.41332494209795190e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72487916088626458e-01</second>
+						<second>-2.84903652915304750e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26449463597276868e-01</second>
+						<second>1.22466784338844015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -70007,34 +70007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39603177060979333e+00</second>
+						<second>1.41428175506590481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06322556202257490e-01</second>
+						<second>-2.65564398948734759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.78087793183815224e-01</second>
+						<second>-9.68833144694997150e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27430259177735383e+00</second>
+						<second>2.36338943969558057e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15239712963725127e+00</second>
+						<second>2.17563150750207912e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70781356256298444e-01</second>
+						<second>-2.55366312168926957e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90530829545758496e-01</second>
+						<second>4.90461073528792202e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45593161267621474e+00</score>
+				<score>9.13031472639708047e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>

--- a/include/reach_ros/evaluation/distance_penalty_moveit.h
+++ b/include/reach_ros/evaluation/distance_penalty_moveit.h
@@ -43,19 +43,22 @@ class DistancePenaltyMoveIt : public reach::Evaluator
 {
 public:
   DistancePenaltyMoveIt(moveit::core::RobotModelConstPtr model, const std::string& planning_group,
-                        const double dist_threshold, int exponent, std::string collision_mesh_filename,
-                        std::vector<std::string> touch_links);
+                        const double dist_threshold, int exponent);
   double calculateScore(const std::map<std::string, double>& pose) const override;
 
-private:
+  void addCollisionMesh(const std::string& collision_mesh_filename, const std::string& collision_mesh_frame);
+
+  void setTouchLinks(const std::vector<std::string>& touch_links);
+
+protected:
   moveit::core::RobotModelConstPtr model_;
   const moveit::core::JointModelGroup* jmg_;
   const double dist_threshold_;
   const int exponent_;
-  const std::string collision_mesh_filename_;
-  const std::vector<std::string> touch_links_;
 
   planning_scene::PlanningScenePtr scene_;
+
+  static std::string COLLISION_OBJECT_NAME;
 };
 
 struct DistancePenaltyMoveItFactory : public reach::EvaluatorFactory

--- a/src/evaluation/distance_penalty_moveit.cpp
+++ b/src/evaluation/distance_penalty_moveit.cpp
@@ -64,7 +64,8 @@ double DistancePenaltyMoveIt::calculateScore(const std::map<std::string, double>
   state.update();
 
   const double dist = scene_->distanceToCollision(state, scene_->getAllowedCollisionMatrix());
-  return std::pow((dist / dist_threshold_), exponent_);
+  const double clipped_distance = std::min(std::abs(dist / dist_threshold_), 1.0);
+  return std::pow(clipped_distance, exponent_);
 }
 
 reach::Evaluator::ConstPtr DistancePenaltyMoveItFactory::create(const YAML::Node& config) const


### PR DESCRIPTION
This PR updates the collision distance evaluator to optionally accept a collision mesh in addition to the shapes defined in the URDF. It also clips the cost on [0, 1] to prevent infinite values when no collisions are detected.