### PR TITLE
Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,8 @@ target_link_libraries(${PROJECT_NAME}_node PUBLIC reach::reach yaml-cpp ${PROJEC
 ament_target_dependencies(${PROJECT_NAME}_node PUBLIC ${ROS2_DEPS})
 
 # Install the libraries
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_plugins EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
+install(TARGETS ${PROJECT_NAME}_plugins DESTINATION lib)
 
 # Install the executable(s)
 install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(${PROJECT_NAME}_plugins PUBLIC ${PROJECT_NAME})
 
 # Reach study node
 add_executable(${PROJECT_NAME}_node src/reach_study_node.cpp)
-target_link_libraries(${PROJECT_NAME}_node PUBLIC reach::reach yaml-cpp ${PROJECT_NAME}_plugins)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC reach::reach yaml-cpp ${PROJECT_NAME})
 ament_target_dependencies(${PROJECT_NAME}_node PUBLIC ${ROS2_DEPS})
 
 # Install the libraries

--- a/include/reach_ros/utils.h
+++ b/include/reach_ros/utils.h
@@ -52,40 +52,11 @@ visualization_msgs::msg::Marker makeMarker(const std::vector<geometry_msgs::msg:
 std::vector<double> transcribeInputMap(const std::map<std::string, double>& input,
                                        const std::vector<std::string>& joint_names);
 
-// declaring the node as external to allow having a single instance when loading the shared library in multiple boost
-// plugins
-extern rclcpp::Node::SharedPtr node;
-
-static rclcpp::Node::SharedPtr getNodeInstance()
-{
-  // static singleton node
-  // we need to create a node that accept arbitrary parameters later
-  // static const rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("reach_study_node",
-  // rclcpp::NodeOptions().allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true));
-  return node;
-}
-
 /**
- * @brief Conditionally initializes ROS using an arbitary node name
- * @details In the case that ROS-enabled plugins are created and invoked in a non-ROS enabled process, ROS must be
- * initialized for the plugins to access the ROS parameter server and publish data. This function should be invoked in a
- * plugin factory or interface before attempting to utilize ROS components such that the process creating the plugin
- * factory. One singleton ROS node is created on the first call of the method and can then be used by all plugins.
- *
- * Note: this function first checks if ROS has already been initialized before calling rclcpp::init
+ * @brief Returns a singleton ROS2 node for accessing parameters and publishing data
+ * @details ROS must be initialized (rclcpp::init, rclpy.init) before calling this method
  */
-static void initROS(int argc, char** argv)
-{
-  static bool ros_initialized = false;
-  if (!ros_initialized)
-  {
-    ros_initialized = true;
-    rclcpp::init(argc, argv);
-    static rclcpp::executors::MultiThreadedExecutor executor = rclcpp::executors::MultiThreadedExecutor();
-    static std::thread executor_thread(std::bind(&rclcpp::executors::MultiThreadedExecutor::spin, &executor));
-    executor.add_node(getNodeInstance());
-  }
-}
+rclcpp::Node::SharedPtr getNodeInstance();
 
 }  // namespace utils
 }  // namespace reach_ros

--- a/src/reach_study_node.cpp
+++ b/src/reach_study_node.cpp
@@ -16,11 +16,8 @@
 #include <reach/reach_study.h>
 #include <reach_ros/utils.h>
 
-#include <thread>
 #include <chrono>
-
-#include <boost/filesystem.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <thread>
 #include <yaml-cpp/yaml.h>
 
 template <typename T>
@@ -32,27 +29,13 @@ T get(const std::shared_ptr<rclcpp::Node> node, const std::string& key)
   return val;
 }
 
-namespace reach_ros
-{
-namespace utils
-{
-// we need to do this since the node is specified as "extern" in the shared library
-rclcpp::Node::SharedPtr node;
-}  // namespace utils
-}  // namespace reach_ros
-
 int main(int argc, char** argv)
 {
-  rclcpp::init(argc, argv);
-  rclcpp::executors::MultiThreadedExecutor executor = rclcpp::executors::MultiThreadedExecutor();
-  std::thread executor_thread(std::bind(&rclcpp::executors::MultiThreadedExecutor::spin, &executor));
-  reach_ros::utils::node = std::make_shared<rclcpp::Node>(
-      "reach_study_node",
-      rclcpp::NodeOptions().allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true));
-  executor.add_node(reach_ros::utils::node);
-
   try
   {
+    // Initialize ROS
+    rclcpp::init(argc, argv);
+
     // Load the configuration information
     const YAML::Node config = YAML::LoadFile(get<std::string>(reach_ros::utils::getNodeInstance(), "config_file"));
     const std::string config_name = get<std::string>(reach_ros::utils::getNodeInstance(), "config_name");
@@ -64,13 +47,8 @@ int main(int argc, char** argv)
   catch (const std::exception& ex)
   {
     std::cerr << ex.what() << std::endl;
-    rclcpp::shutdown();
-    executor_thread.join();
     return -1;
   }
-
-  rclcpp::shutdown();
-  executor_thread.join();
 
   return 0;
 }

--- a/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
@@ -23,7 +23,7 @@ reach::VectorIsometry3d TransformedPointCloudTargetPoseGenerator::generate() con
   reach::VectorIsometry3d target_poses = PointCloudTargetPoseGenerator::generate();
 
   // Look up the transform between the source and target frame
-  tf2_ros::Buffer buffer(utils::node->get_clock());
+  tf2_ros::Buffer buffer(utils::getNodeInstance()->get_clock());
   tf2_ros::TransformListener listener(buffer);
   Eigen::Isometry3d transform = tf2::transformToEigen(
       buffer.lookupTransform(target_frame_, points_frame_, tf2::TimePointZero, tf2::durationFromSec(3.0)));


### PR DESCRIPTION
This PR updates the ROS interface singleton pattern to allow the plugin library from this library to be loaded dynamically from within Python and for downstream custom plugins to be able to link against the interface implementations in this repo. This PR partially addresses #13. My guess is that the primary issue was that the `extern` declaration of the node singleton. Since the node was provided in the c++ reach study executable (and not in the library itself), the node singleton looked like an undefined reference to any other executable that tried to load it.

Although this PR allows ROS2-enabled plugins to be loaded in Python, they won't actually work in a Python script because `rclcpp::init` needs to be called first with the contents of `argv` (i.e. parameters, etc.). I tried calling `rclpy.init()` in the Python script instead (see below), but that doesn't seem to do the trick. I think we'll need to add a small Python interface to this repo for invoking `rclcpp::init` from Python. I propose that be done in a separate PR

```python
import yaml
from reach import runReachStudy, PluginLoader
import rclpy
import sys


def main():
    rclpy.init(args=sys.argv)
    if not rclpy.ok():
        raise RuntimeError('ROS is not running')

    yaml_path = 'config/reach_study.yaml'
    with open(yaml_path) as f:
        config = yaml.safe_load(f)

    loader = PluginLoader()
    loader.search_libraries_env = 'REACH_PLUGINS'

    # Works correctly now
    solver = loader.createIKSolverFactoryInstance('MoveItIKSolver')

    # Fails because `rclcpp::ok()` returns false in the c++ plugin library, even though `rclpy.init` was called in this executable
    res = runReachStudy(config)


if __name__ == '__main__':
    main()

```