### PR TITLE
Export dependency on reach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,4 +93,5 @@ install(DIRECTORY launch demo DESTINATION share/${PROJECT_NAME})
 
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${ROS2_DEPS})
+ament_export_dependencies(reach)
 ament_package()


### PR DESCRIPTION
Changes per commit message. Without this, downstream projects that `find_package(reach_ros)` also need to `find_package(reach)`, which should be done automatically and transitively