### PR TITLE
Fix deprecated headers for tf2_eigen

### DIFF
--- a/include/reach_ros/utils.h
+++ b/include/reach_ros/utils.h
@@ -23,7 +23,11 @@
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/interactive_marker.hpp>
 #include <tf2/convert.h>
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
+#else
+#include <tf2_eigen/tf2_eigen.h>
+#endif
 #include <map>
 
 namespace reach

--- a/include/reach_ros/utils.h
+++ b/include/reach_ros/utils.h
@@ -23,7 +23,7 @@
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/interactive_marker.hpp>
 #include <tf2/convert.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <map>
 
 namespace reach

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -17,7 +17,7 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <yaml-cpp/yaml.h>
 
 const static std::string JOINT_STATES_TOPIC = "reach_joints";

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -17,7 +17,11 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
+#else
+#include <tf2_eigen/tf2_eigen.h>
+#endif
 #include <yaml-cpp/yaml.h>
 
 const static std::string JOINT_STATES_TOPIC = "reach_joints";

--- a/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
@@ -2,7 +2,7 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <yaml-cpp/yaml.h>

--- a/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
@@ -2,7 +2,11 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
+#else
+#include <tf2_eigen/tf2_eigen.h>
+#endif
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <yaml-cpp/yaml.h>


### PR DESCRIPTION
The `.h` headers for `tf2_eigen` are deprecated since humble and were removed in 0.36 (currently on rolling). They have to be renamed to `.hpp`.