### PR TITLE
Change durability policy of mesh display to transient_local

### DIFF
--- a/launch/reach_study_config.rviz
+++ b/launch/reach_study_config.rviz
@@ -127,7 +127,7 @@ Visualization Manager:
         "": true
       Topic:
         Depth: 5
-        Durability Policy: Volatile
+        Durability Policy: Transient Local
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -43,7 +43,7 @@ ROSDisplay::ROSDisplay(std::string kinematic_base_frame, double marker_scale, bo
   joint_state_pub_ =
       reach_ros::utils::getNodeInstance()->create_publisher<sensor_msgs::msg::JointState>(JOINT_STATES_TOPIC, 1);
   mesh_pub_ =
-      reach_ros::utils::getNodeInstance()->create_publisher<visualization_msgs::msg::Marker>(MESH_MARKER_TOPIC, 1);
+      reach_ros::utils::getNodeInstance()->create_publisher<visualization_msgs::msg::Marker>(MESH_MARKER_TOPIC, rclcpp::QoS(1).transient_local());
   neighbors_pub_ =
       reach_ros::utils::getNodeInstance()->create_publisher<visualization_msgs::msg::Marker>(NEIGHBORS_MARKER_TOPIC, 1);
 }


### PR DESCRIPTION
This makes it possible to untick and retick the display marker for the collision mesh in rviz, allowing for a better view of interactive markers in an occluded environment. The change is backward compatible because a subscriber with durability policy volatile can still receive messages from a publisher with durability policy transient local.