### PR TITLE
Fixes for 24.04 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.7)
 # Extract package name and version from package.xml
 find_package(ros_industrial_cmake_boilerplate REQUIRED)
 extract_package_metadata(pkg)
-project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX C)
 
 option(BUILD_PYTHON "Build Python bindings" ON)
 

--- a/include/reach_ros/utils.h
+++ b/include/reach_ros/utils.h
@@ -23,7 +23,7 @@
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/interactive_marker.hpp>
 #include <tf2/convert.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <map>
 
 namespace reach

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -17,7 +17,7 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <yaml-cpp/yaml.h>
 
 const static std::string JOINT_STATES_TOPIC = "reach_joints";

--- a/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
@@ -2,7 +2,7 @@
 #include <reach_ros/utils.h>
 
 #include <reach/plugin_utils.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <yaml-cpp/yaml.h>


### PR DESCRIPTION
Related to https://github.com/ros-industrial/reach/pull/83

* Fix MPI_C not found error similar to https://github.com/ros-industrial/reach/pull/82
* Use tf2_eigen.hpp instead of tf2_eigen.h https://github.com/ros2/geometry2/pull/645