### PR TITLE
Update to later version of RICB that adds hook for PYTHONPATH

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,7 +1,7 @@
 - git:
    local-name: ros_industrial_cmake_boilerplate
    uri: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
-   version: 0.4.6
+   version: 0.4.7
 - git:
    local-name: boost_plugin_loader
    uri: https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
Per https://github.com/ros-industrial/reach/pull/51 the `vcs import` of this repository was importing an older version of RICB that did not import the version with the fix required to work with Reach bindings.

Small PR to fix this.