### PR TITLE
Add dockerfile and compose files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [humble, rolling, jazzy]
+        distro: [foxy, humble, jazzy]
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'docker/Dockerfile'
+      - '.github/workflows/docker.yml'
+      - 'dependencies.repos'
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [humble, rolling, jazzy]
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      PUSH_DOCKER_IMAGE: ${{ github.ref == 'refs/heads/master' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker meta-information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          tags: |
+            type=ref,event=branch,prefix=${{ matrix.distro }}-
+            type=ref,event=pr,prefix=${{ matrix.distro }}-
+            type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.distro }}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: |
+            DISTRO=${{ matrix.distro }}
+          push: ${{ env.PUSH_DOCKER_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-ARG TAG
 FROM moveit/moveit2:jazzy-release
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ USER root
 ARG WORKSPACE_DIR=/tmpfs/reach_ros
 ARG INSTALL_DIR=/opt/reach_ros
 RUN apt update -y -qq \
-    && rosdep update
+    && rosdep update --include-eol-distros
   
 # Build the repository
 # Bind mount the source directory so as not to unnecessarily copy source code into the docker image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+ARG TAG
+FROM moveit/moveit2:jazzy-release
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+USER root
+
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+ARG WORKSPACE_DIR=/tmpfs/reach_ros
+ARG INSTALL_DIR=/opt/reach_ros
+RUN apt update -y -qq \
+    && rosdep update
+  
+# Build the repository
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+RUN --mount=type=tmpfs,target=${WORKSPACE_DIR} --mount=type=bind,target=${WORKSPACE_DIR}/src/reach_ros2 \
+  cd ${WORKSPACE_DIR} \ 
+  && source /opt/ros/jazzy/setup.bash \
+  && vcs import ${WORKSPACE_DIR}/src < ${WORKSPACE_DIR}/src/reach_ros2/dependencies.repos --shallow \
+  && rosdep install \
+    --from-paths ${WORKSPACE_DIR}/src \
+    -iry \
+  && colcon build --cmake-args \
+  && cp -r ${WORKSPACE_DIR}/install ${INSTALL_DIR}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM moveit/moveit2:jazzy-release
+ARG DISTRO=jazzy
+FROM ros:${DISTRO}
+ARG DISTRO
 
 SHELL ["/bin/bash", "-c"]
 
@@ -16,10 +18,10 @@ RUN apt update -y -qq \
 # Bind mount the source directory so as not to unnecessarily copy source code into the docker image
 RUN --mount=type=tmpfs,target=${WORKSPACE_DIR} --mount=type=bind,target=${WORKSPACE_DIR}/src/reach_ros2 \
   cd ${WORKSPACE_DIR} \ 
-  && source /opt/ros/jazzy/setup.bash \
+  && source /opt/ros/${DISTRO}/setup.bash \
   && vcs import ${WORKSPACE_DIR}/src < ${WORKSPACE_DIR}/src/reach_ros2/dependencies.repos --shallow \
   && rosdep install \
     --from-paths ${WORKSPACE_DIR}/src \
     -iry \
-  && colcon build --cmake-args \
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
   && cp -r ${WORKSPACE_DIR}/install ${INSTALL_DIR}

--- a/docker/demo.docker-compose.yml
+++ b/docker/demo.docker-compose.yml
@@ -1,0 +1,17 @@
+
+services:
+  setup:
+    container_name: reach_study_setup
+    extends:    
+      file: docker-compose.yml
+      service: reach_ros
+    command: /bin/bash -c "source /opt/reach_ros/setup.bash 
+                          && ros2 launch reach_ros setup.launch.py"
+
+  reach_study:
+    container_name: reach_study
+    extends:
+      file: docker-compose.yml
+      service: reach_ros
+    command: /bin/bash -c "source /opt/reach_ros/setup.bash 
+                          && ros2 launch reach_ros start.launch.py"

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,12 @@
+# Uncomment for use with GPU
+# services:
+#   noether:
+#     environment:
+#       NVIDIA_DRIVER_CAPABILITIES: all
+#     deploy:
+#       resources:
+#         reservations:
+#           devices:
+#             - driver: nvidia
+#               count: 1
+#               capabilities: [gpu]

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,6 +1,6 @@
 # Uncomment for use with GPU
 # services:
-#   noether:
+#   reach_ros:
 #     environment:
 #       NVIDIA_DRIVER_CAPABILITIES: all
 #     deploy:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  reach_ros:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      # args:
+      #   - TAG=humble-0.29
+    environment:
+      DISPLAY: $DISPLAY
+      XAUTHORITY: $XAUTHORITY
+      NVIDIA_DRIVER_CAPABILITIES: all
+      ROS_LOG_DIR: /tmp
+    container_name: reach_ros
+    image: ghcr.io/ros-industrial/reach_ros2:jazzy-master
+    stdin_open: true
+    tty: true
+    network_mode: host
+    privileged: true
+    user: ${CURRENT_UID}  # CURRENT_UID=$(id -u):$(id -g)
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /etc/hosts:/etc/hosts
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     stdin_open: true
     tty: true
     network_mode: host
+    ipc: host
     privileged: true
     user: ${CURRENT_UID}  # CURRENT_UID=$(id -u):$(id -g)
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '3'
+version: '1'
 services:
   reach_ros:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-      # args:
-      #   - TAG=humble-0.29
     environment:
       DISPLAY: $DISPLAY
       XAUTHORITY: $XAUTHORITY

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      args:
+        - DISTRO=jazzy
     environment:
       DISPLAY: $DISPLAY
       XAUTHORITY: $XAUTHORITY

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
### Description
Based on discussion #43, this MR adds a dockerfile and relevant compose files. This will help update the existing images and allow extending the current Dockerfile for reach dependent applications.

### Changes
`docker/Dockerfile`: Dockerfile that builds the reach_ros2 image. I have based it off of `moveit/moveit2:jazzy-release` to save build time. But we could go for a lighter base and install dependencies. Let me know if this is the preferred approach.
`docker/docker-compose.yml`: Main compose file with the reach_ros default startup arguments
`docker/docker-compose.override.yml`: An override file that allows gpu usage on devices with a gpu.
`docker/demo.docker-compose.yml`: A convenient compose file that reuses the built image and runs the default motoman demo.

### Test
In the root of repository
```bash
CURRENT_UID=$(id -u):$(id -g) docker compose -f docker/demo.docker-compose.yml up --build
```
You should expect the container to be built, two services running and an Rviz window pop up with the same view as in the README