### PR TITLE
Add transformed yaml pose generator plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ add_library(
   # Display
   src/display/ros_display.cpp
   # Target pose generator
-  src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp)
+  src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+  src/target_pose_generator/transformed_yaml_target_pose_generator.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                                   $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC reach::reach)
@@ -89,7 +90,7 @@ install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 
 # Install the support directories
-install(DIRECTORY launch demo DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY launch demo runs DESTINATION share/${PROJECT_NAME})
 
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${ROS2_DEPS})

--- a/include/reach_ros/target_pose_generator/transformed_yaml_target_pose_generator.h
+++ b/include/reach_ros/target_pose_generator/transformed_yaml_target_pose_generator.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef REACH_ROS_TARGET_POSE_GENERATOR_YAML_TARGET_POSE_GENERATOR_H
+#define REACH_ROS_TARGET_POSE_GENERATOR_YAML_TARGET_POSE_GENERATOR_H
+
+#include <reach/plugins/yaml_target_pose_generator.h>
+
+namespace reach_ros
+{
+class TransformedYAMLTargetPoseGenerator : public reach::YAMLTargetPoseGenerator
+{
+public:
+  TransformedYAMLTargetPoseGenerator(std::string filename, std::string source_frame, std::string target_frame);
+
+  reach::VectorIsometry3d generate() const override;
+
+private:
+  std::string filename_;
+  std::string points_frame_;
+  std::string target_frame_;
+};
+
+struct TransformedYAMLTargetPoseGeneratorFactory : public reach::YAMLTargetPoseGeneratorFactory
+{
+  using YAMLTargetPoseGeneratorFactory::YAMLTargetPoseGeneratorFactory;
+  reach::TargetPoseGenerator::ConstPtr create(const YAML::Node& config) const override;
+};
+
+}  // namespace reach_ros
+
+#endif  // REACH_ROS_TARGET_POSE_GENERATOR_YAML_TARGET_POSE_GENERATOR_H

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -4,6 +4,7 @@
 #include <reach_ros/evaluation/manipulability_moveit.h>
 #include <reach_ros/ik/moveit_ik_solver.h>
 #include <reach_ros/target_pose_generator/transformed_point_cloud_target_pose_generator.h>
+#include <reach_ros/target_pose_generator/transformed_yaml_target_pose_generator.h>
 
 #include <reach/plugin_utils.h>
 EXPORT_DISPLAY_PLUGIN(reach_ros::display::ROSDisplayFactory, ROSDisplay)
@@ -16,3 +17,5 @@ EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::MoveItIKSolverFactory, MoveItIKSolver)
 EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::DiscretizedMoveItIKSolverFactory, DiscretizedMoveItIKSolver)
 EXPORT_TARGET_POSE_GENERATOR_PLUGIN(reach_ros::TransformedPointCloudTargetPoseGeneratorFactory,
                                     TransformedPointCloudTargetPoseGenerator)
+EXPORT_TARGET_POSE_GENERATOR_PLUGIN(reach_ros::TransformedYAMLTargetPoseGeneratorFactory,
+                                    TransformedYAMLTargetPoseGenerator)

--- a/src/target_pose_generator/transformed_yaml_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_yaml_target_pose_generator.cpp
@@ -1,0 +1,53 @@
+#include <reach_ros/target_pose_generator/transformed_yaml_target_pose_generator.h>
+#include <reach_ros/utils.h>
+
+#include <reach/plugin_utils.h>
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
+#include <tf2_eigen/tf2_eigen.hpp>
+#else
+#include <tf2_eigen/tf2_eigen.h>
+#endif
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <yaml-cpp/yaml.h>
+
+namespace reach_ros
+{
+TransformedYAMLTargetPoseGenerator::TransformedYAMLTargetPoseGenerator(std::string filename,
+                                                                     std::string points_frame,
+                                                                     std::string target_frame)
+  : reach::YAMLTargetPoseGenerator(filename)
+  , points_frame_(std::move(points_frame))
+  , target_frame_(std::move(target_frame))
+{
+}
+
+reach::VectorIsometry3d TransformedYAMLTargetPoseGenerator::generate() const
+{
+  reach::VectorIsometry3d target_poses = YAMLTargetPoseGenerator::generate();
+
+  // Look up the transform between the source and target frame
+  tf2_ros::Buffer buffer(utils::getNodeInstance()->get_clock());
+  tf2_ros::TransformListener listener(buffer);
+  Eigen::Isometry3d transform = tf2::transformToEigen(
+      buffer.lookupTransform(target_frame_, points_frame_, tf2::TimePointZero, tf2::durationFromSec(3.0)));
+
+  // Apply the transform to the poses
+  for (Eigen::Isometry3d& pose : target_poses)
+  {
+    pose = transform * pose;
+  }
+
+  return target_poses;
+}
+
+reach::TargetPoseGenerator::ConstPtr
+TransformedYAMLTargetPoseGeneratorFactory::create(const YAML::Node& config) const
+{
+  std::string filename = reach::get<std::string>(config, "poses");
+  std::string source_frame = reach::get<std::string>(config, "points_frame");
+  std::string target_frame = reach::get<std::string>(config, "target_frame");
+  return std::make_shared<TransformedYAMLTargetPoseGenerator>(filename, source_frame, target_frame);
+}
+
+}  // namespace reach_ros

--- a/src/target_pose_generator/transformed_yaml_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_yaml_target_pose_generator.cpp
@@ -13,9 +13,8 @@
 
 namespace reach_ros
 {
-TransformedYAMLTargetPoseGenerator::TransformedYAMLTargetPoseGenerator(std::string filename,
-                                                                     std::string points_frame,
-                                                                     std::string target_frame)
+TransformedYAMLTargetPoseGenerator::TransformedYAMLTargetPoseGenerator(std::string filename, std::string points_frame,
+                                                                       std::string target_frame)
   : reach::YAMLTargetPoseGenerator(filename)
   , points_frame_(std::move(points_frame))
   , target_frame_(std::move(target_frame))
@@ -41,8 +40,7 @@ reach::VectorIsometry3d TransformedYAMLTargetPoseGenerator::generate() const
   return target_poses;
 }
 
-reach::TargetPoseGenerator::ConstPtr
-TransformedYAMLTargetPoseGeneratorFactory::create(const YAML::Node& config) const
+reach::TargetPoseGenerator::ConstPtr TransformedYAMLTargetPoseGeneratorFactory::create(const YAML::Node& config) const
 {
   std::string filename = reach::get<std::string>(config, "poses");
   std::string source_frame = reach::get<std::string>(config, "points_frame");


### PR DESCRIPTION
## Description

Based on the discussion [here](https://github.com/ros-industrial/reach/discussions/33#discussioncomment-13750425), and a [related PR](https://github.com/ros-industrial/reach/pull/89), this PR adds a transform plugin for the YAMLTargetPoseGenerator that allows transforming the target points between two TF frames.

It's basically repeated code from an existing plugin called `TransformedPointCloudTargetPoseGenerator` with the class name changed. It could be useful to think of ways to not repeat such code. Maybe creating a templated Transformer class could help. 
Or if we don't expect many other classes that use the transformation then this is ok for now I think.
Let me know what you think @marip8  
