### PR TITLE
Remove implicit rotation of target pose

### DIFF
--- a/demo/model/reach_study.xacro
+++ b/demo/model/reach_study.xacro
@@ -7,6 +7,6 @@
   <joint name="tool0_to_tcp" type="fixed">
     <parent link="tool0"/>
     <child link="tcp"/>
-    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <origin xyz="0 0 0.1" rpy="3.14 0 0"/>
   </joint>
 </robot>

--- a/demo/model/reach_study.xacro
+++ b/demo/model/reach_study.xacro
@@ -7,6 +7,6 @@
   <joint name="tool0_to_tcp" type="fixed">
     <parent link="tool0"/>
     <child link="tcp"/>
-    <origin xyz="0 0 0.1" rpy="3.14 0 0"/>
+    <origin xyz="0 0 0.1" rpy="${radians(180)} 0 0"/>
   </joint>
 </robot>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -122,11 +122,10 @@ visualization_msgs::msg::Marker makeVisual(const reach::ReachRecord& r, const st
 
   // Transform arrow such that arrow x-axis points along goal pose z-axis (Rviz convention)
   // convert msg parameter goal to Eigen matrix
-  Eigen::AngleAxisd rot_flip_normal(M_PI, Eigen::Vector3d::UnitX());
   Eigen::AngleAxisd rot_x_to_z(-M_PI / 2, Eigen::Vector3d::UnitY());
 
   // Transform
-  Eigen::Isometry3d goal_eigen = r.goal * rot_flip_normal * rot_x_to_z;
+  Eigen::Isometry3d goal_eigen = r.goal * rot_x_to_z;
 
   // Convert back to geometry_msgs pose
   geometry_msgs::msg::Pose msg = tf2::toMsg(goal_eigen);


### PR DESCRIPTION
The reach packages is updated in [this MR](https://github.com/ros-industrial/reach/pull/90) which removes the assumption that target pose z-axis is opposing tool z-axis.
This MR updates the URDF and visualizations to respect this new change.