### PR TITLE
Set REACH_PLUGINS variable using an env hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ install(DIRECTORY launch demo DESTINATION share/${PROJECT_NAME})
 
 # Install hook so REACH_PLUGINS env. var is updated appropriately
 ament_environment_hooks(
-  "${CMAKE_CURRENT_SOURCE_DIR}/hooks/reach_env_var.sh.in"
+  "${CMAKE_CURRENT_SOURCE_DIR}/hooks/reach_env_var.dsv.in"
 )
 
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 # Install the support directories
 install(DIRECTORY launch demo DESTINATION share/${PROJECT_NAME})
 
+# Install hook so REACH_PLUGINS env. var is updated appropriately
+ament_environment_hooks(
+  "${CMAKE_CURRENT_SOURCE_DIR}/hooks/reach_env_var.sh.in"
+)
+
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${ROS2_DEPS})
 ament_export_dependencies(reach)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,7 @@ install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
 install(DIRECTORY launch demo DESTINATION share/${PROJECT_NAME})
 
 # Install hook so REACH_PLUGINS env. var is updated appropriately
-ament_environment_hooks(
-  "${CMAKE_CURRENT_SOURCE_DIR}/hooks/reach_env_var.dsv.in"
-)
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/reach_env_var.dsv.in")
 
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${ROS2_DEPS})

--- a/hooks/reach_env_var.dsv.in
+++ b/hooks/reach_env_var.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;REACH_PLUGINS;lib/@PROJECT_NAME@_plugins

--- a/hooks/reach_env_var.sh.in
+++ b/hooks/reach_env_var.sh.in
@@ -1,2 +1,5 @@
+# Ensure that the REACH_PLUGINS environment variable is exported (ament_... does not do this)
+export REACH_PLUGINS="${REACH_PLUGINS:-}"
+
 # Append reach plugin library name to REACH_PLUGINS (if not already present)
 ament_append_unique_value REACH_PLUGINS "@PROJECT_NAME@_plugins"

--- a/hooks/reach_env_var.sh.in
+++ b/hooks/reach_env_var.sh.in
@@ -1,0 +1,4 @@
+# Append reach plugin library name to REACH_PLUGINS (if not already present)
+if [[ ":$REACH_PLUGINS:" != *":reach_ros_plugins:"* ]]; then
+    export REACH_PLUGINS="${REACH_PLUGINS:+$REACH_PLUGINS:}reach_ros_plugins"
+fi

--- a/hooks/reach_env_var.sh.in
+++ b/hooks/reach_env_var.sh.in
@@ -1,5 +1,0 @@
-# Ensure that the REACH_PLUGINS environment variable is exported (ament_... does not do this)
-export REACH_PLUGINS="${REACH_PLUGINS:-}"
-
-# Append reach plugin library name to REACH_PLUGINS (if not already present)
-ament_append_unique_value REACH_PLUGINS "@PROJECT_NAME@_plugins"

--- a/hooks/reach_env_var.sh.in
+++ b/hooks/reach_env_var.sh.in
@@ -1,4 +1,2 @@
 # Append reach plugin library name to REACH_PLUGINS (if not already present)
-if [[ ":$REACH_PLUGINS:" != *":reach_ros_plugins:"* ]]; then
-    export REACH_PLUGINS="${REACH_PLUGINS:+$REACH_PLUGINS:}reach_ros_plugins"
-fi
+ament_append_unique_value REACH_PLUGINS "@PROJECT_NAME@_plugins"

--- a/launch/start.launch.py
+++ b/launch/start.launch.py
@@ -55,8 +55,6 @@ def launch(context, *args, **kwargs):
     kinematics_yaml = load_yaml(robot_description_kinematics_file.perform(context))
     joint_limits_yaml = load_yaml(robot_description_joints_limits_file.perform(context))
 
-    os.environ['REACH_PLUGINS'] = 'reach_ros_plugins'
-
     return [
         Node(
             package='reach_ros',


### PR DESCRIPTION
## Description

Currently, the `REACH_PLUGINS` environment variable is set in the `start.launch.py` launch file, and its contents are hardcoded. If one wants to load more reach plugin libraries, the launch file needs to be changed (or a different launch file needs to be made).

A more flexible way to set the variable is to use an environment hook, which runs when the workspace is sourced and adds the necessary plugin library names to the variable, if they are not already present. Then, the environment variable doesn't have to be tampered with in the launch file, as it already contains all the available reach plugin libraries for the currently sourced workspace.

~~Note that `dsv` hooks can't be used, since they append full paths. This breaks compatibility with Windows, but to my knowledge reach is not target at Windows (at least none of the CI builds on windows).~~

## Changes

- Add a simple environment hook to prepend the plugin library name if not already present
- Remove environment variable override from launch file

## Test

Running the example:

```bash
ros2 launch reach_ros setup.launch.py
ros2 launch reach_ros start.launch.py # In a different terminal
```

Works just as before.

To ensure the library name is added to the variable successfully, try the following:

```bash
unset REACH_PLUGINS
source install/setup.bash
bash -c 'echo ${REACH_PLUGINS}' # To ensure the variable is exported properly
```

This should print all registered plugin libraries, separated by colons. For a workspace with only `reach_ros2` plugins, this should yield `/path-to/lib/reach_ros_plugins`.

To ensure the prepending behaviour works, run the following:

```bash
export REACH_PLUGINS=my_reach_plugins
source install/setup.bash
bash -c 'echo ${REACH_PLUGINS}'
```

This should yield `/path-to/lib/reach_ros_plugins:my_reach_plugins` (if no other plugin libraries exist in the workspace).

To ensure that prepending without overwriting works, use the following:

```bash
export REACH_PLUGINS=/path-to/lib/reach_ros_plugins
source install/setup.bash
bash -c 'echo ${REACH_PLUGINS}'
```

This should yield `/path-to/lib/reach_ros_plugins`.
